### PR TITLE
video: mxc_hdmi: Flag video modes from the fallback list as standard.

### DIFF
--- a/drivers/video/mxc/mxc_hdmi.c
+++ b/drivers/video/mxc/mxc_hdmi.c
@@ -2742,8 +2742,11 @@ static int mxc_hdmi_disp_init(struct mxc_dispdrv_handle *disp,
 	/*Add all no interlaced CEA mode to default modelist */
 	for (i = 0; i < ARRAY_SIZE(mxc_cea_mode); i++) {
 		mode = &mxc_cea_mode[i];
-		if (!(mode->vmode & FB_VMODE_INTERLACED) && (mode->xres != 0))
-			fb_add_videomode(mode, &hdmi->fbi->modelist);
+		if (!(mode->vmode & FB_VMODE_INTERLACED) && (mode->xres != 0)) {
+			struct fb_videomode m = *mode;
+			m.flag |= FB_MODE_IS_STANDARD;
+			fb_add_videomode(&m, &hdmi->fbi->modelist);
+		}
 	}
 
 	console_unlock();


### PR DESCRIPTION
This patch changes the fallback modes from 'User' to 'Standard' (i.e. they get listed as S:xxxx instead of U:xxxx), which makes them usable by XBMC/Kodi
