### PR TITLE
Change / fix audio descriptor handling

### DIFF
--- a/include/video/mxc_edid.h
+++ b/include/video/mxc_edid.h
@@ -90,9 +90,8 @@ struct mxc_edid_cfg {
 	u16 hdmi_3d_struct_all;
 	u32 vsd_max_tmdsclk_rate;
 
-	u8 max_channels;
-	u8 sample_sizes;
-	u8 sample_rates;
+	u8 sample_sizes[4];
+	u8 sample_rates[4];
 	u8 speaker_alloc;
 };
 

--- a/sound/soc/fsl/fsl_hdmi.c
+++ b/sound/soc/fsl/fsl_hdmi.c
@@ -335,6 +335,83 @@ static void fsl_hdmi_get_playback_channels(void)
 		pr_debug("%s: constraint = %d channels\n", __func__, playback_channels[i]);
 }
 
+static int fsl_hw_rule_channels_by_rate(struct snd_pcm_hw_params *params,
+                                        struct snd_pcm_hw_rule *rule)
+{
+	struct snd_interval	*r = hw_param_interval(params, SNDRV_PCM_HW_PARAM_RATE);
+	struct snd_interval	*c = hw_param_interval(params, SNDRV_PCM_HW_PARAM_CHANNELS);
+	int    			i;
+	u8     			m;
+	struct snd_interval	n;
+
+	if (snd_interval_single(r)) {
+		m = 0;
+		for (i = 0; i < HDMI_MAX_RATES; i++) {
+			if (snd_interval_min(r) == cea_audio_rates[i]) {
+				m = 1 << i;
+				break;
+			}
+		}
+
+		if (m) {
+			snd_interval_any(&n);
+			n.min = n.max = 2;
+
+			for (i = 1; i < ARRAY_SIZE(edid_cfg.sample_rates); i++) {
+				if (!(edid_cfg.sample_rates[i] & m))
+					break;
+				n.max += 2;
+			}
+
+			pr_debug("%s: rate = %d, channels = %d..%d\n",
+				 __func__, r->min, n.min, n.max);
+
+			return snd_interval_refine(c, &n);
+		}
+	}
+
+	return 0;
+}
+
+static int fsl_hw_rule_rate_by_channels(struct snd_pcm_hw_params *params,
+                                        struct snd_pcm_hw_rule *rule)
+{
+	struct snd_interval	*r = hw_param_interval(params, SNDRV_PCM_HW_PARAM_RATE);
+	struct snd_interval	*c = hw_param_interval(params, SNDRV_PCM_HW_PARAM_CHANNELS);
+	int    			i, rate;
+	u8     			m;
+	struct snd_interval	n;
+
+	if (snd_interval_single(c)) {
+		i = (snd_interval_min(c) - 1) / 2;
+		m = edid_cfg.sample_rates[i];
+
+		if (m) {
+			snd_interval_any(&n);
+			n.min = 192000;
+			n.max = 32000;
+
+			for (i = 0; i < HDMI_MAX_RATES; i++, m >>= 1) {
+				if (!(m & 1))
+					  continue;
+
+				rate = cea_audio_rates[i];
+				if ( rate < n.min)
+					n.min = rate;
+				if ( rate > n.max)
+					n.max = rate;
+			}
+
+			pr_debug("%s: channels = %d, rates = %d..%d\n",
+				 __func__, c->min, n.min, n.max);
+
+			return snd_interval_refine(r, &n);
+		}
+	}
+
+	return 0;
+}
+
 static int fsl_hdmi_update_constraints(struct snd_pcm_substream *substream)
 {
 	struct snd_pcm_runtime *runtime = substream->runtime;
@@ -364,6 +441,18 @@ static int fsl_hdmi_update_constraints(struct snd_pcm_substream *substream)
 		return ret;
 
 	ret = snd_pcm_hw_constraint_integer(runtime, SNDRV_PCM_HW_PARAM_PERIODS);
+	if (ret < 0)
+		return ret;
+
+	ret = snd_pcm_hw_rule_add(runtime, 0, SNDRV_PCM_HW_PARAM_CHANNELS,
+			fsl_hw_rule_channels_by_rate, NULL,
+			SNDRV_PCM_HW_PARAM_RATE, -1);
+	if (ret < 0)
+		return ret;
+
+	ret = snd_pcm_hw_rule_add(runtime, 0, SNDRV_PCM_HW_PARAM_RATE,
+			fsl_hw_rule_rate_by_channels, NULL,
+			SNDRV_PCM_HW_PARAM_CHANNELS, -1);
 	if (ret < 0)
 		return ret;
 

--- a/sound/soc/fsl/fsl_hdmi.c
+++ b/sound/soc/fsl/fsl_hdmi.c
@@ -348,23 +348,23 @@ static int fsl_hdmi_update_constraints(struct snd_pcm_substream *substream)
 	fsl_hdmi_get_playback_rates();
 	ret = snd_pcm_hw_constraint_list(runtime, 0, SNDRV_PCM_HW_PARAM_RATE,
 			&playback_constraint_rates);
-	if (ret)
+	if (ret < 0)
 		return ret;
 
 	fsl_hdmi_get_playback_sample_size();
 	ret = snd_pcm_hw_constraint_list(runtime, 0, SNDRV_PCM_HW_PARAM_SAMPLE_BITS,
 			&playback_constraint_bits);
-	if (ret)
+	if (ret < 0)
 		return ret;
 
 	fsl_hdmi_get_playback_channels();
 	ret = snd_pcm_hw_constraint_list(runtime, 0, SNDRV_PCM_HW_PARAM_CHANNELS,
 			&playback_constraint_channels);
-	if (ret)
+	if (ret < 0)
 		return ret;
 
 	ret = snd_pcm_hw_constraint_integer(runtime, SNDRV_PCM_HW_PARAM_PERIODS);
-	if (ret)
+	if (ret < 0)
 		return ret;
 
 	return 0;

--- a/sound/soc/fsl/fsl_hdmi.c
+++ b/sound/soc/fsl/fsl_hdmi.c
@@ -277,10 +277,11 @@ static int cea_audio_rates[HDMI_MAX_RATES] = {
 static void fsl_hdmi_get_playback_rates(void)
 {
 	int i, count = 0;
-	u8 rates;
+	u8 rates = edid_cfg.sample_rates[0] | edid_cfg.sample_rates[1] |
+			edid_cfg.sample_rates[2] | edid_cfg.sample_rates[3];
 
 	/* Always assume basic audio support */
-	rates = edid_cfg.sample_rates | 0x7;
+	rates |= 0x07;
 
 	for (i = 0 ; i < HDMI_MAX_RATES ; i++)
 		if ((rates & (1 << i)) != 0)
@@ -296,11 +297,13 @@ static void fsl_hdmi_get_playback_rates(void)
 static void fsl_hdmi_get_playback_sample_size(void)
 {
 	int i = 0;
+	u8 sizes = edid_cfg.sample_sizes[0] | edid_cfg.sample_sizes[1] |
+			edid_cfg.sample_sizes[2] | edid_cfg.sample_sizes[3];
 
 	/* Always assume basic audio support */
 	playback_sample_size[i++] = 16;
 
-	if (edid_cfg.sample_sizes & 0x4)
+	if (sizes & 0x4)
 		playback_sample_size[i++] = 32;
 
 	playback_constraint_bits.list = playback_sample_size;
@@ -318,8 +321,9 @@ static void fsl_hdmi_get_playback_channels(void)
 	playback_channels[i++] = channels;
 	channels += 2;
 
-	while ((i < HDMI_MAX_CHANNEL_CONSTRAINTS) &&
-			(channels <= edid_cfg.max_channels)) {
+	while (i < HDMI_MAX_CHANNEL_CONSTRAINTS &&
+	       i < ARRAY_SIZE(edid_cfg.sample_rates) &&
+	       edid_cfg.sample_rates[i] && edid_cfg.sample_sizes[i]) {
 		playback_channels[i++] = channels;
 		channels += 2;
 	}


### PR DESCRIPTION
This patch corrects the behavior in case a sink supports different sample rates in stereo and multichannel mode. There are some AVRs around, that report a maximum sample rate of 192kHz for two-channel operation and 96kHz in 4..8 channel output. Therefore we need to adjust the sample rate constraints in ALSA accordingly in order not to exceed the AVR's capabilities. The theory, this should also be done for the sample bit count as well. But since an IEC958 frame is always 32 bits, it should be O.K. to send more (valid) data bits than needed. The restructuring also does not zero the detected sample rate / bit count at the beginning of each Audio Data Block, as LPCM descriptors might be scattered across more than one of them.
