### PR TITLE
shutdown: udoo: Toggle GPIO pin and properly shutdown on machine_halt…

### DIFF
--- a/arch/arm/kernel/process.c
+++ b/arch/arm/kernel/process.c
@@ -48,6 +48,11 @@ unsigned long __stack_chk_guard __read_mostly;
 EXPORT_SYMBOL(__stack_chk_guard);
 #endif
 
+/* udoo shutdown */
+#include <linux/gpio.h>
+#define IMX_GPIO_NR(bank, nr)	(((bank) - 1) * 32 + (nr))
+#define UDOO_HALT_GPIO		IMX_GPIO_NR(2, 4)
+
 static const char *processor_modes[] = {
   "USER_26", "FIQ_26" , "IRQ_26" , "SVC_26" , "UK4_26" , "UK5_26" , "UK6_26" , "UK7_26" ,
   "UK8_26" , "UK9_26" , "UK10_26", "UK11_26", "UK12_26", "UK13_26", "UK14_26", "UK15_26",
@@ -192,6 +197,22 @@ void machine_shutdown(void)
 	disable_nonboot_cpus();
 }
 
+void udoo_qdl_halt(void)
+{
+	int ret;
+
+	if (!of_machine_is_compatible("udoo,imx6q-udoo") && !of_machine_is_compatible("udoo,imx6dl-udoo"))
+		return;
+
+	ret = gpio_request(UDOO_HALT_GPIO, "HALT");
+	if (ret) {
+		printk(KERN_EMERG "Failed to get HALT gpio: %d\n", ret);
+	} else {
+		printk(KERN_EMERG "Udoo shutdown\n");
+		gpio_direction_output(UDOO_HALT_GPIO, 1);
+	}
+}
+
 /*
  * Halting simply requires that the secondary CPUs stop performing any
  * activity (executing tasks, handling interrupts). smp_send_stop()
@@ -203,6 +224,7 @@ void machine_halt(void)
 	smp_send_stop();
 
 	local_irq_disable();
+	udoo_qdl_halt();
 	while (1);
 }
 
@@ -219,6 +241,8 @@ void machine_power_off(void)
 
 	if (pm_power_off)
 		pm_power_off();
+
+	udoo_qdl_halt();
 }
 
 /*


### PR DESCRIPTION
…() and machine_power_off()

copied from https://github.com/UDOOboard/linux_kernel/commit/7f2ebadc98a9294544860dfe64217dccc6d4aef4
