### PR TITLE
net: fec: Fix kernel oops when no phy is detected

### DIFF
--- a/drivers/net/ethernet/freescale/fec_main.c
+++ b/drivers/net/ethernet/freescale/fec_main.c
@@ -3412,7 +3412,7 @@ fec_probe(struct platform_device *pdev)
 
 	ret = fec_enet_mii_probe(ndev);
 	if (ret)
-		goto failed_register;
+		goto failed_mii_probe;
 
 	phy_start_aneg(fep->phy_dev);
 
@@ -3426,6 +3426,8 @@ fec_probe(struct platform_device *pdev)
 	INIT_WORK(&fep->tx_timeout_work, fec_enet_timeout_work);
 	return 0;
 
+failed_mii_probe:
+	unregister_netdev(ndev);
 failed_register:
 	fec_enet_mii_remove(fep);
 failed_mii_init:


### PR DESCRIPTION
The device need to be unregistered when fec_enet_mii_probe() fails. Otherwise we get an oops in free_netdev().
