### PR TITLE
leds: Fix support for low-active PWM LED

### DIFF
--- a/Documentation/devicetree/bindings/leds/leds-pwm.txt
+++ b/Documentation/devicetree/bindings/leds/leds-pwm.txt
@@ -17,6 +17,8 @@ LED sub-node properties:
   see Documentation/devicetree/bindings/leds/common.txt
 - linux,default-trigger :  (optional)
   see Documentation/devicetree/bindings/leds/common.txt
+- active-low : (optional)
+  Inverts the duty cycle to reflect a low-active output pin
 
 Example:
 
@@ -38,6 +40,7 @@ pwmleds {
 		label = "omap4::keypad";
 		pwms = <&twl_pwm 0 7812500>;
 		max-brightness = <127>;
+		active-low;
 	};
 
 	charging {

--- a/drivers/leds/leds-pwm.c
+++ b/drivers/leds/leds-pwm.c
@@ -70,6 +70,10 @@ static void led_pwm_set(struct led_classdev *led_cdev,
 
 	duty *= brightness;
 	do_div(duty, max);
+
+	if (led_dat->active_low)
+		duty = led_dat->period - duty;
+
 	led_dat->duty = duty;
 
 	if (led_dat->can_sleep)
@@ -117,6 +121,7 @@ static int led_pwm_create_of(struct platform_device *pdev,
 
 		led_dat->cdev.default_trigger = of_get_property(child,
 						"linux,default-trigger", NULL);
+		led_dat->active_low = of_property_read_bool(child, "active-low");
 		of_property_read_u32(child, "max-brightness",
 				     &led_dat->cdev.max_brightness);
 


### PR DESCRIPTION
Support for the 'low-active ' property was only partially implemented.
