### PR TITLE
net: fec: Properly shutdown time_keep work queue

### DIFF
--- a/drivers/net/ethernet/freescale/fec_main.c
+++ b/drivers/net/ethernet/freescale/fec_main.c
@@ -3456,6 +3456,8 @@ failed_register:
 failed_mii_init:
 failed_irq:
 failed_init:
+	if (fep->bufdesc_ex)
+		cancel_delayed_work_sync(&fep->time_keep);
 	if (fep->reg_phy)
 		regulator_disable(fep->reg_phy);
 	if (fep->ptp_clock)
@@ -3477,7 +3479,8 @@ fec_drv_remove(struct platform_device *pdev)
 	struct net_device *ndev = platform_get_drvdata(pdev);
 	struct fec_enet_private *fep = netdev_priv(ndev);
 
-	cancel_delayed_work_sync(&fep->time_keep);
+	if (fep->bufdesc_ex)
+		cancel_delayed_work_sync(&fep->time_keep);
 	cancel_work_sync(&fep->tx_timeout_work);
 	unregister_netdev(ndev);
 	fec_enet_mii_remove(fep);


### PR DESCRIPTION
The work queue callback initialize in fec_ptp_init() must be terminated in case the PHY is not probed successfully. However, we should not do this, in case it was not initialised at all. This fixes  #17.
