### PR TITLE
mxc_hdmi: save & restore xres_virtual/yres_virtual with (re)applying …

### DIFF
--- a/drivers/video/mxc/mxc_edid.c
+++ b/drivers/video/mxc/mxc_edid.c
@@ -793,3 +793,50 @@ int mxc_edid_read(struct i2c_adapter *adp, unsigned short addr,
 }
 EXPORT_SYMBOL(mxc_edid_read);
 
+const struct fb_videomode *mxc_fb_find_nearest_mode(const struct fb_videomode *mode,
+						    struct list_head *head, bool relax)
+{
+	struct list_head *pos;
+	struct fb_modelist *modelist;
+	struct fb_videomode *cmode;
+	static struct fb_videomode *best;
+	static u32 diff, diff_refresh;
+	u32 mask = relax ? FB_VMODE_MASK_SIMPLE | FB_VMODE_ASPECT_MASK : ~0;
+
+	if (!relax) {
+		diff = -1;
+		diff_refresh = -1;
+		best = NULL;
+	}
+
+	list_for_each(pos, head) {
+		u32 d;
+
+		modelist = list_entry(pos, struct fb_modelist, list);
+		cmode = &modelist->mode;
+
+		if ((mode->vmode ^ cmode->vmode) & mask)
+				continue;
+
+		d = abs(cmode->xres - mode->xres) +
+			abs(cmode->yres - mode->yres);
+		if (diff > d) {
+			diff = d;
+			diff_refresh = abs(cmode->refresh - mode->refresh);
+			best = cmode;
+		} else if (diff == d) {
+			d = abs(cmode->refresh - mode->refresh);
+			if (diff_refresh > d) {
+				diff_refresh = d;
+				best = cmode;
+			}
+		}
+	}
+
+	if ((!relax && (diff_refresh || diff)) || !best)
+		mxc_fb_find_nearest_mode(mode, head, true);
+
+	return best;
+}
+EXPORT_SYMBOL(mxc_fb_find_nearest_mode);
+

--- a/drivers/video/mxc/mxc_edid.c
+++ b/drivers/video/mxc/mxc_edid.c
@@ -192,6 +192,21 @@ const struct fb_videomode mxc_cea_mode[64] = {
 	},
 };
 
+/* 0x8 is FB_VMODE_FRACT (not yet merged) */
+#define FB_VMODE_MASK_SIMPLE (FB_VMODE_NONINTERLACED | FB_VMODE_INTERLACED | 0x8)
+
+int mxc_fb_mode_is_equal_res(const struct fb_videomode *mode1,
+			     const struct fb_videomode *mode2)
+{
+	return (mode1->xres         == mode2->xres &&
+		mode1->yres         == mode2->yres &&
+		mode1->refresh      == mode2->refresh &&
+		mode1->sync         == mode2->sync &&
+		(mode1->vmode & FB_VMODE_MASK_SIMPLE) ==
+		(mode2->vmode & FB_VMODE_MASK_SIMPLE));
+}
+EXPORT_SYMBOL(mxc_fb_mode_is_equal_res);
+
 /*
  * We have a special version of fb_mode_is_equal that ignores
  * pixclock, since for many CEA modes, 2 frequencies are supported

--- a/include/video/mxc_edid.h
+++ b/include/video/mxc_edid.h
@@ -105,4 +105,6 @@ int mxc_edid_read(struct i2c_adapter *adp, unsigned short addr,
 	unsigned char *edid, struct mxc_edid_cfg *cfg, struct fb_info *fbi);
 int mxc_edid_parse_ext_blk(unsigned char *edid, struct mxc_edid_cfg *cfg,
 	struct fb_monspecs *specs);
+const struct fb_videomode *mxc_fb_find_nearest_mode(const struct fb_videomode *mode,
+                                                    struct list_head *head, bool relax);
 #endif

--- a/include/video/mxc_edid.h
+++ b/include/video/mxc_edid.h
@@ -107,4 +107,5 @@ int mxc_edid_parse_ext_blk(unsigned char *edid, struct mxc_edid_cfg *cfg,
 	struct fb_monspecs *specs);
 const struct fb_videomode *mxc_fb_find_nearest_mode(const struct fb_videomode *mode,
                                                     struct list_head *head, bool relax);
+int mxc_fb_mode_is_equal_res(const struct fb_videomode *mode1, const struct fb_videomode *mode2);
 #endif


### PR DESCRIPTION
…screen modes.
- mxc_hdmi_set_mode() is restoring previous mode from saved structure which doesn't
  contain virtual dimensions (double/triple buffer).
- this reallocates fb mem to one page and makes page flipping not work
- restoring setup + mxc_hdmi_notify_fb() ensures proper allocations again
