### PR TITLE
Fix hd audio passthrough on 6ch sinks

### DIFF
--- a/drivers/video/mxc/mxc_edid.c
+++ b/drivers/video/mxc/mxc_edid.c
@@ -559,6 +559,14 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 							DPRINTK("Sample Sizes            : %02x\n",
 								byte3 & 0x7);
 						}
+
+						/* HD-audio: pretend to support 192kHz/16bit in 8ch mode to
+						 * allow HD passthrough on sinks that report only 6ch LPCM */
+						if (audio_format == AUDIO_CODING_TYPE_MLP ||
+						    audio_format == AUDIO_CODING_TYPE_DTS_HD) {
+							cfg->sample_rates[3] |= 0x40;
+							cfg->sample_sizes[3] |= 0x01;
+						}
 					}
 					break;
 				}

--- a/drivers/video/mxc/mxc_edid.c
+++ b/drivers/video/mxc/mxc_edid.c
@@ -543,17 +543,17 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 						index += 3;
 						i += 3;
 
-						audio_format = byte1 >> 3;
+						audio_format = (byte1 & 0x7f) >> 3;
 
 						DPRINTK("Audio Format Descriptor : %2d\n", audio_format);
 						DPRINTK("Max Number of Channels  : %2d\n", (byte1 & 0x07) + 1);
-						DPRINTK("Sample Rates            : %02x\n", byte2);
+						DPRINTK("Sample Rates            : %02x\n", byte2 & 0x7f);
 
 						/* ALSA can't specify specific compressed
 						 * formats, so only care about PCM for now. */
 						if (audio_format == AUDIO_CODING_TYPE_LPCM) {
 							for (ch_idx = (byte1 & 0x07) / 2; ch_idx >= 0; ch_idx--) {
-								cfg->sample_rates[ch_idx] |= byte2;
+								cfg->sample_rates[ch_idx] |= byte2 & 0x7f;
 								cfg->sample_sizes[ch_idx] |= byte3 & 0x7;
 							}
 							DPRINTK("Sample Sizes            : %02x\n",
@@ -574,7 +574,7 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 				{
 					i = 0;
 					while (i < blklen) {
-						cfg->speaker_alloc = edid[index + 1];
+						cfg->speaker_alloc = edid[index + 1] & 0x7f;
 						index += 3;
 						i += 3;
 						DPRINTK("Speaker Alloc           : %02x\n", cfg->speaker_alloc);


### PR DESCRIPTION
The stricter constraints introduced in https://github.com/SolidRun/linux-fslc/pull/5 have an unexpected side effect. They prevent enabling hd audio passthrough on sinks, that report less than 8 LPCM channels. This patch relaxes these constraints so that 8 channels @ 192kHz will be accepted in case the sink indicates support for hd audio formats.
Furthermore some unused bits are masked when parsing the EDID audio info. These bits are currently always zero, but may gain a meaning in future versions of the CEA861 standard.
