### PR TITLE
video: mxc_edid: Ignore unknown 'Vendor Specific Data'

### DIFF
--- a/drivers/video/mxc/mxc_edid.c
+++ b/drivers/video/mxc/mxc_edid.c
@@ -363,7 +363,7 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 				}
 			case 0x3: /*Vendor specific data*/
 				{
-					unsigned char IEEE_reg_iden[3];
+					unsigned      IEEE_reg_iden;
 					unsigned char deep_color;
 					unsigned char latency_present;
 					unsigned char I_latency_present;
@@ -372,23 +372,32 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 					unsigned char hdmi_3d_multi_present;
 					unsigned char hdmi_vic_len;
 					unsigned char hdmi_3d_len;
-					unsigned char index_inc = 0;
+					unsigned char index_inc;
 					unsigned char vsd_end;
 
-					vsd_end = index + blklen;
+					IEEE_reg_iden = (blklen > 2) ?
+						((edid[index+3] << 16) | (edid[index+2] << 8) | edid[index+1]) : 0;
 
-					IEEE_reg_iden[0] = edid[index+1];
-					IEEE_reg_iden[1] = edid[index+2];
-					IEEE_reg_iden[2] = edid[index+3];
-					cfg->physical_address[0] = (edid[index+4] & 0xf0) >> 4;
-					cfg->physical_address[1] = (edid[index+4] & 0x0f);
-					cfg->physical_address[2] = (edid[index+5] & 0xf0) >> 4;
-					cfg->physical_address[3] = (edid[index+5] & 0x0f);
+					if (IEEE_reg_iden != 0x000c03) {
+						DPRINTK("VSD block OUI=0x%06x present\n", IEEE_reg_iden);
+						index += blklen;
+						break;
+					}
 
-					if ((IEEE_reg_iden[0] == 0x03) &&
-							(IEEE_reg_iden[1] == 0x0c) &&
-							(IEEE_reg_iden[2] == 0x00))
+					DPRINTK("VSD block HDMI 1.x 'HDMI Licensing, LLC' present\n");
+
+					if (blklen > 4) {
 						cfg->hdmi_cap = 1;
+
+						cfg->physical_address[0] = edid[index+4] >> 4;
+						cfg->physical_address[1] = edid[index+4] & 0x0f;
+						cfg->physical_address[2] = edid[index+5] >> 4;
+						cfg->physical_address[3] = edid[index+5] & 0x0f;
+
+						DPRINTK("VSD physical address 0x%x%x%x%x\n",
+							cfg->physical_address[0], cfg->physical_address[1],
+							cfg->physical_address[2], cfg->physical_address[3]);
+					}
 
 					if (blklen > 5) {
 						deep_color = edid[index+6];
@@ -440,6 +449,7 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 						break;
 					}
 
+					vsd_end = index + blklen;
 					index += 9;
 
 					/*latency present */
@@ -482,6 +492,8 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 						}
 
 						if (hdmi_3d_len > 0) {
+							index_inc = 0;
+
 							if (hdmi_3d_present) {
 								if (hdmi_3d_multi_present == 0x1) {
 									cfg->hdmi_3d_struct_all = (edid[index] << 8) | edid[index+1];
@@ -490,8 +502,7 @@ int mxc_edid_parse_ext_blk(unsigned char *edid,
 									cfg->hdmi_3d_struct_all = (edid[index] << 8) | edid[index+1];
 									cfg->hdmi_3d_mask_all = (edid[index+2] << 8) | edid[index+3];
 									index_inc = 4;
-								} else
-									index_inc = 0;
+								}
 							}
 
 							DPRINTK("HDMI 3d struct all =0x%x\n", cfg->hdmi_3d_struct_all);


### PR DESCRIPTION
The HDMI specification allows multiple vendor specific data blocks to be present in the EDID. While this was rather uncommon in HDMI 1.x, it is the default for HDMI 2.x ports. This patch ensures that only the block with the IEEE registration identifier of 'HDMI Licensing, LLC' is used to extract HDMI capabilities.
