### PR TITLE
ARM: dts: hummingboard: fix eMMC with SOM rev 1.5 on Pro

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-hummingboard-som-v15.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-hummingboard-som-v15.dtsi
@@ -310,20 +310,24 @@
                                  * gpio72      | (3,8)           | IO12
                                  * gpio71      | (3,7)           | IO13
                                  * gpio70      | (3,6)           | IO15
-                                 * gpio194     | (7,2)           | IO16
-                                 * gpio195     | (7,3)           | IO18
+                                 * gpio194     | (7,2)           | IO16(*)
+                                 * gpio195     | (7,3)           | IO18(*)
                                  * gpio67      | (3,3)           | IO22
                                  *
                                  * Notice the gpioX and GPIO (Y,Z) mapping forumla :
                                  * X = (Y-1) * 32 + Z
+                                 *
+                                 * (*) These pins are not usable when the SOM
+                                 *     has eMMC. Their mux is commented out
+                                 *     below.
                                  */
                                 MX6QDL_PAD_GPIO_1__GPIO1_IO01 0x400130b1
                                 MX6QDL_PAD_EIM_DA9__GPIO3_IO09 0x400130b1
                                 MX6QDL_PAD_EIM_DA8__GPIO3_IO08 0x400130b1
                                 MX6QDL_PAD_EIM_DA7__GPIO3_IO07 0x400130b1
                                 MX6QDL_PAD_EIM_DA6__GPIO3_IO06 0x400130b1
-                                MX6QDL_PAD_SD3_CMD__GPIO7_IO02 0x400130b1
-                                MX6QDL_PAD_SD3_CLK__GPIO7_IO03 0x400130b1
+                                /*MX6QDL_PAD_SD3_CMD__GPIO7_IO02 0x400130b1*/
+                                /*MX6QDL_PAD_SD3_CLK__GPIO7_IO03 0x400130b1*/
                                 MX6QDL_PAD_EIM_DA3__GPIO3_IO03 0x400130b1
                         >;
                 };


### PR DESCRIPTION
The Hummingboard Pro/Base use two of the eMMC pins in their pins header.
Comment these pins out to make eMMC detection work on SOM rev 1.5.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>