### PR TITLE
imx-hdmi-dma: Shift 24bit data to the right when assembling IEC958 frame

### DIFF
--- a/sound/soc/fsl/imx-hdmi-dma.c
+++ b/sound/soc/fsl/imx-hdmi-dma.c
@@ -279,6 +279,11 @@ static u32 hdmi_dma_add_frame_info(struct hdmi_dma_priv *priv,
 	/* fill data */
 	if (priv->sample_bits == 16)
 		pcm_data <<= 8;
+	else
+		pcm_data >>= 8;
+	/* this is probably a workaround for a bug in the pcm subsystem     */
+	/* shifting should not be needed when using SNDRV_PCM_FORMAT_S24_LE */
+
 	subframe.B.data = pcm_data;
 
 	/* fill p (parity) Note: Do not include b ! */


### PR DESCRIPTION
This is most likely a workaround for a bug in the PCM subsystem that is not present in 3.x kernels.

Signed-off-by: Rudi <r.ihle@s-t.de>