### PR TITLE
leds-pwm: Check for valid PWM instance before initializing led_pwm_data

### DIFF
--- a/drivers/leds/leds-pwm.c
+++ b/drivers/leds/leds-pwm.c
@@ -310,15 +310,6 @@ static int led_pwm_add(struct device *dev, struct led_pwm_priv *priv,
 	struct pwm_args pargs;
 	int ret;
 
-	led_data->active_low = led->active_low;
-	led_data->cdev.name = led->name;
-	led_data->cdev.default_trigger = led->default_trigger;
-	led_data->cdev.brightness = LED_OFF;
-	led_data->cdev.max_brightness = led->max_brightness;
-	led_data->cdev.flags = LED_CORE_SUSPENDRESUME;
-	led_data->octave = 4;
-	led_data->period = led_data->pwm->state.period;
-
 	if (child)
 		led_data->pwm = devm_of_pwm_get(dev, child, NULL);
 	else
@@ -329,6 +320,15 @@ static int led_pwm_add(struct device *dev, struct led_pwm_priv *priv,
 			led->name, ret);
 		return ret;
 	}
+
+	led_data->active_low = led->active_low;
+	led_data->cdev.name = led->name;
+	led_data->cdev.default_trigger = led->default_trigger;
+	led_data->cdev.brightness = LED_OFF;
+	led_data->cdev.max_brightness = led->max_brightness;
+	led_data->cdev.flags = LED_CORE_SUSPENDRESUME;
+	led_data->octave = 4;
+	led_data->period = led_data->pwm->state.period;
 
 	led_data->can_sleep = pwm_can_sleep(led_data->pwm);
 	if (!led_data->can_sleep)


### PR DESCRIPTION
Here is a fix for #48