### PR TITLE
Imx 4.9.x 1.0.0 ga 24bit audio fix

### DIFF
--- a/sound/core/pcm_lib.c
+++ b/sound/core/pcm_lib.c
@@ -1416,8 +1416,15 @@ static int snd_pcm_hw_rule_msbits(struct snd_pcm_hw_params *params,
 	int width = l & 0xffff;
 	unsigned int msbits = l >> 16;
 	struct snd_interval *i = hw_param_interval(params, SNDRV_PCM_HW_PARAM_SAMPLE_BITS);
+	struct snd_mask *m = hw_param_mask(params, SNDRV_PCM_HW_PARAM_FORMAT);
 
-	if (!snd_interval_single(i))
+	if (!snd_interval_single(i) || !snd_mask_single(m))
+		return 0;
+
+	if (snd_mask_test(m, SNDRV_PCM_FORMAT_S24_LE) ||
+	    snd_mask_test(m, SNDRV_PCM_FORMAT_S24_BE) ||
+	    snd_mask_test(m, SNDRV_PCM_FORMAT_U24_LE) ||
+	    snd_mask_test(m, SNDRV_PCM_FORMAT_U24_BE))
 		return 0;
 
 	if ((snd_interval_value(i) == width) ||

--- a/sound/soc/fsl/imx-hdmi-dma.c
+++ b/sound/soc/fsl/imx-hdmi-dma.c
@@ -279,11 +279,6 @@ static u32 hdmi_dma_add_frame_info(struct hdmi_dma_priv *priv,
 	/* fill data */
 	if (priv->sample_bits == 16)
 		pcm_data <<= 8;
-	else
-		pcm_data >>= 8;
-	/* this is probably a workaround for a bug in the pcm subsystem     */
-	/* shifting should not be needed when using SNDRV_PCM_FORMAT_S24_LE */
-
 	subframe.B.data = pcm_data;
 
 	/* fill p (parity) Note: Do not include b ! */


### PR DESCRIPTION
This patch introduces a more generic solution to the problem that 649e3b739569b8959714308237b8d1554c540e71 was supposed to address. It reverts the beforementioned patch and introduces the approach 'change pcm_lib to ignore sig_bits when LSB-justification is in effect' mentioned in #47