### PR TITLE
Rework CEC driver for kernel 4.9

### DIFF
--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -628,7 +628,7 @@ static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 	poll_wait(file, &rx_queue, wait);
 	poll_wait(file, &tx_queue, wait);
 
-	if (priv->link_status == 1 &&
+	if (priv->link_status == 0 ||
 	    priv->tx_answer == CEC_TX_AVAIL)
 		mask |= POLLOUT | POLLWRNORM;
 

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -133,7 +133,7 @@ static irqreturn_t mxc_hdmi_cec_isr(int irq, void *data)
 
 void mxc_hdmi_cec_handle(u16 cec_stat)
 {
-	u8 val = 0, i = 0;
+	u8 i = 0;
 	struct hdmi_cec_event *event = NULL;
 
 	/* The current transmission is successful (for initiator only). */
@@ -172,29 +172,16 @@ void mxc_hdmi_cec_handle(u16 cec_stat)
 
 	/* An error is detected on cec line (for initiator only). */
 	if (cec_stat & HDMI_IH_CEC_STAT0_ERROR_INIT) {
-		mutex_lock(&hdmi_cec_data.lock);
-		hdmi_cec_data.send_error++;
-		if (hdmi_cec_data.send_error > 2) {
-			pr_err("%s:Re-transmission is attempted more than 2 times!\n", __func__);
-			hdmi_cec_data.send_error = 0;
-			mutex_unlock(&hdmi_cec_data.lock);
-			hdmi_cec_data.tx_answer = cec_stat;
-			wake_up(&tx_cec_queue);
-			return;
-		}
-		for (i = 0; i < hdmi_cec_data.msg_len; i++)
-			hdmi_writeb(hdmi_cec_data.last_msg[i], HDMI_CEC_TX_DATA0+i);
-		hdmi_writeb(hdmi_cec_data.msg_len, HDMI_CEC_TX_CNT);
-		val = hdmi_readb(HDMI_CEC_CTRL);
-		val |= 0x01;
-		hdmi_writeb(val, HDMI_CEC_CTRL);
-		mutex_unlock(&hdmi_cec_data.lock);
+		hdmi_cec_data.tx_answer = cec_stat;
+		wake_up(&tx_cec_queue);
+		return;
 	}
 	/* A frame is not acknowledged in a directly addressed message.
 	 * Or a frame is negatively acknowledged in
 	 * a broadcast message (for initiator only).
 	 */
 	if (cec_stat & HDMI_IH_CEC_STAT0_NACK) {
+		hdmi_cec_data.send_error++;
 		hdmi_cec_data.tx_answer = cec_stat;
 		wake_up(&tx_cec_queue);
 	}
@@ -395,7 +382,7 @@ static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
 		     u_long arg)
 {
 	int ret = 0, status = 0;
-	u8 val = 0, msg = 0;
+	u8 val = 0;
 	struct mxc_edid_cfg hdmi_edid_cfg;
 	pr_debug("function : %s\n", __func__);
 	if (!open_count)
@@ -419,15 +406,6 @@ static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
 			hdmi_writeb(0, HDMI_CEC_ADDR_L);
 		} else
 			ret = -EINVAL;
-		/*Send Polling message with same source and destination address*/
-		if (0 == ret && 15 != hdmi_cec_data.Logical_address) {
-			msg = (hdmi_cec_data.Logical_address << 4)|hdmi_cec_data.Logical_address;
-			hdmi_writeb(1, HDMI_CEC_TX_CNT);
-			hdmi_writeb(msg, HDMI_CEC_TX_DATA0);
-			val = hdmi_readb(HDMI_CEC_CTRL);
-			val |= 0x01;
-			hdmi_writeb(val, HDMI_CEC_CTRL);
-		}
 		mutex_unlock(&hdmi_cec_data.lock);
 		break;
 	case HDMICEC_IOC_STARTDEVICE:

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -96,6 +96,7 @@ struct hdmi_cec_event {
 };
 
 
+static LIST_HEAD(ev_idle);
 static LIST_HEAD(ev_pending);
 
 static int hdmi_cec_irq;
@@ -108,6 +109,60 @@ static u8 is_initialized;
 
 static wait_queue_head_t rx_queue;
 static wait_queue_head_t tx_queue;
+
+static struct hdmi_cec_event *alloc_event(void)
+{
+	int i;
+	struct hdmi_cec_event *event;
+
+	if (list_empty(&ev_idle)) {
+		event = (void *)__get_free_page(GFP_KERNEL);
+
+		if (!event) {
+			pr_err("HDMI-CEC: Failed to allocate event buffer\n");
+			return NULL;
+		}
+
+		for (i = 1; i < PAGE_SIZE / sizeof(struct hdmi_cec_event); i++)
+		      list_add_tail(&event[i].list, &ev_idle);
+
+		pr_debug("HDMI-CEC: Allocated event buffer page: @%08lx (%d)\n",
+			 (unsigned long)event, i);
+	} else {
+		event = list_first_entry(&ev_idle, struct hdmi_cec_event, list);
+		list_del(&event->list);
+	}
+
+	memset(event, 0, sizeof(struct hdmi_cec_event));
+	return event;
+}
+
+static void free_events(void)
+{
+	struct hdmi_cec_event *event, *tmp_event;
+
+	/* Flush events which have not been read by user space */
+	list_splice_init(&ev_pending, &ev_idle);
+
+	/* Find item(s) starting on a page boundary */
+	list_for_each_entry_safe(event, tmp_event, &ev_idle, list) {
+		if (((unsigned long)event & ~PAGE_MASK) == 0)
+			list_move_tail(&event->list, &ev_pending);
+	}
+
+	/* Discard idle list */
+	INIT_LIST_HEAD(&ev_idle);
+
+	/* Empty pending list and free page(s) */
+	while (!list_empty(&ev_pending)) {
+		event = list_first_entry(&ev_pending, struct hdmi_cec_event, list);
+		list_del(&event->list);
+		free_page((unsigned long)event);
+
+		pr_debug("HDMI-CEC: Freed event buffer page: @%08lx\n",
+			 (unsigned long)event);
+	}
+}
 
 static u32 get_hpd_stat(struct hdmi_cec_priv *hdmi_cec)
 {
@@ -156,11 +211,28 @@ static irqreturn_t mxc_hdmi_cec_isr(int irq, void *data)
 
 static void mxc_hdmi_cec_handle(u32 cec_stat)
 {
-	u8 i = 0;
-	struct hdmi_cec_event *event = NULL;
+	int i;
+	struct hdmi_cec_event *event;
 
 	if (!hdmi_cec_data.open_count)
 		return;
+
+	/*HDMI cable connected: handle first*/
+	if (cec_stat & CEC_STAT0_EX_CONNECTED) {
+		pr_info("HDMI-CEC: link connected\n");
+
+		mutex_lock(&hdmi_cec_data.lock);
+		event = alloc_event();
+		if (!event) {
+			mutex_unlock(&hdmi_cec_data.lock);
+			return;
+		}
+		event->event_type = MESSAGE_TYPE_CONNECTED;
+		list_add_tail(&event->list, &ev_pending);
+		mutex_unlock(&hdmi_cec_data.lock);
+
+		wake_up(&rx_queue);
+	}
 
 	/* The current transmission is successful (for initiator only). */
 	if (cec_stat & HDMI_IH_CEC_STAT0_DONE) {
@@ -170,25 +242,28 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 
 	/*EOM is detected so that the received data is ready in the receiver data buffer*/
 	if (cec_stat & HDMI_IH_CEC_STAT0_EOM) {
-		event = vmalloc(sizeof(struct hdmi_cec_event));
-		if (NULL == event) {
-			pr_err("%s: Not enough memory!\n", __func__);
+		mutex_lock(&hdmi_cec_data.lock);
+		event = alloc_event();
+		if (!event) {
+			mutex_unlock(&hdmi_cec_data.lock);
 			return;
 		}
-		memset(event, 0, sizeof(struct hdmi_cec_event));
+
 		event->msg_len = hdmi_readb(HDMI_CEC_RX_CNT);
-		if (!event->msg_len) {
-			pr_err("%s: Invalid CEC message length!\n", __func__);
-			vfree(event);
+		if (!event->msg_len || event->msg_len > MAX_MESSAGE_LEN) {
+			pr_err("HDMI-CEC: Invalid CEC message length\n");
+			list_add_tail(&event->list, &ev_idle);
+			mutex_unlock(&hdmi_cec_data.lock);
 			return;
 		}
+
 		event->event_type = MESSAGE_TYPE_RECEIVE_SUCCESS;
 		for (i = 0; i < event->msg_len; i++)
-			event->msg[i] = hdmi_readb(HDMI_CEC_RX_DATA0+i);
-		hdmi_writeb(0x0, HDMI_CEC_LOCK);
-		mutex_lock(&hdmi_cec_data.lock);
+			event->msg[i] = hdmi_readb(HDMI_CEC_RX_DATA0 + i);
+
 		list_add_tail(&event->list, &ev_pending);
 		mutex_unlock(&hdmi_cec_data.lock);
+
 		wake_up(&rx_queue);
 	}
 
@@ -215,35 +290,20 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 		hdmi_cec_data.receive_error++;
 	}
 
-	/* HDMI cable connected */
-	if (cec_stat & CEC_STAT0_EX_CONNECTED) {
-		pr_info("HDMI-CEC: link connected\n");
-		pr_info("HDMI link connected\n");
-		event = vmalloc(sizeof(struct hdmi_cec_event));
-		if (NULL == event) {
-			pr_err("%s: Not enough memory\n", __func__);
-			return;
-		}
-		memset(event, 0, sizeof(struct hdmi_cec_event));
-		event->event_type = MESSAGE_TYPE_CONNECTED;
-		mutex_lock(&hdmi_cec_data.lock);
-		list_add_tail(&event->list, &ev_pending);
-		mutex_unlock(&hdmi_cec_data.lock);
-		wake_up(&rx_queue);
-	}
-	/*HDMI cable disconnected*/
+	/*HDMI cable disconnected: handle last*/
 	if (cec_stat & CEC_STAT0_EX_DISCONNECTED) {
 		pr_info("HDMI-CEC: link disconnected\n");
-		event = vmalloc(sizeof(struct hdmi_cec_event));
-		if (NULL == event) {
-			pr_err("%s: Not enough memory!\n", __func__);
+
+		mutex_lock(&hdmi_cec_data.lock);
+		event = alloc_event();
+		if (!event) {
+			mutex_unlock(&hdmi_cec_data.lock);
 			return;
 		}
-		memset(event, 0, sizeof(struct hdmi_cec_event));
 		event->event_type = MESSAGE_TYPE_DISCONNECTED;
-		mutex_lock(&hdmi_cec_data.lock);
 		list_add_tail(&event->list, &ev_pending);
 		mutex_unlock(&hdmi_cec_data.lock);
+
 		wake_up(&rx_queue);
 	}
 }
@@ -253,6 +313,9 @@ static void mxc_hdmi_cec_worker(struct work_struct *work)
 	unsigned long flags;
 
 	mxc_hdmi_cec_handle(hdmi_cec_data.cec_stat0);
+
+	if (hdmi_cec_data.cec_stat0 & HDMI_IH_CEC_STAT0_EOM)
+		hdmi_writeb(0x0, HDMI_CEC_LOCK);
 
 	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
 	hdmi_cec_data.cec_stat0 = 0;
@@ -279,7 +342,8 @@ static int hdmi_cec_open(struct inode *inode, struct file *file)
 static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 			    loff_t *ppos)
 {
-	struct hdmi_cec_event *event = NULL;
+	ssize_t len;
+	struct hdmi_cec_event *event;
 
 	pr_debug("function : %s\n", __func__);
 
@@ -293,26 +357,24 @@ static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 		if (file->f_flags & O_NONBLOCK) {
 			mutex_unlock(&hdmi_cec_data.lock);
 			return -EAGAIN;
-		} else {
-			do {
-				mutex_unlock(&hdmi_cec_data.lock);
-				if (wait_event_interruptible(rx_queue, !list_empty(&ev_pending)))
-					return -ERESTARTSYS;
-				mutex_lock(&hdmi_cec_data.lock);
-			} while (list_empty(&ev_pending));
 		}
+
+		do {
+			mutex_unlock(&hdmi_cec_data.lock);
+			if (wait_event_interruptible(rx_queue, !list_empty(&ev_pending)))
+				return -ERESTARTSYS;
+			mutex_lock(&hdmi_cec_data.lock);
+		} while (list_empty(&ev_pending));
 	}
 
+	len = offsetof(struct hdmi_cec_event, list);
 	event = list_first_entry(&ev_pending, struct hdmi_cec_event, list);
-	list_del(&event->list);
+	if (copy_to_user(buf, event, len))
+		len = -EFAULT;
+	list_move_tail(&event->list, &ev_idle);
 	mutex_unlock(&hdmi_cec_data.lock);
-	if (copy_to_user(buf, event,
-			 sizeof(struct hdmi_cec_event) - sizeof(struct list_head))) {
-		vfree(event);
-		return -EFAULT;
-	}
-	vfree(event);
-	return (sizeof(struct hdmi_cec_event) - sizeof(struct list_head));
+
+	return len;
 }
 
 static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
@@ -503,8 +565,6 @@ static long hdmi_cec_ioctl(struct file *file, u_int cmd,
 
 static int hdmi_cec_release(struct inode *inode, struct file *file)
 {
-	struct hdmi_cec_event *event, *tmp_event;
-
 	pr_debug("function : %s\n", __func__);
 
 	mutex_lock(&hdmi_cec_data.lock);
@@ -513,11 +573,7 @@ static int hdmi_cec_release(struct inode *inode, struct file *file)
 		hdmi_cec_data.is_started = false;
 		hdmi_cec_data.logical_address = 15;
 
-		/* Flush eventual events which have not been read by user space */
-		list_for_each_entry_safe(event, tmp_event, &ev_pending, list) {
-			list_del(&event->list);
-			vfree(event);
-		}
+		free_events();
 	}
 	mutex_unlock(&hdmi_cec_data.lock);
 
@@ -592,6 +648,7 @@ static int hdmi_cec_dev_probe(struct platform_device *pdev)
 		goto err_out_class;
 	}
 
+	INIT_LIST_HEAD(&ev_idle);
 	INIT_LIST_HEAD(&ev_pending);
 
 	init_waitqueue_head(&rx_queue);

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -355,8 +355,6 @@ static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 	struct hdmi_cec_event *event;
 	struct hdmi_cec_priv *priv = file->private_data;
 
-	pr_debug("function : %s\n", __func__);
-
 	mutex_lock(&priv->lock);
 
 	if (!priv->is_started)
@@ -402,8 +400,6 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	u8 msg[MAX_MESSAGE_LEN];
 	struct hdmi_cec_event *event;
 	struct hdmi_cec_priv *priv = file->private_data;
-
-	pr_debug("function : %s\n", __func__);
 
 	mutex_lock(&priv->lock);
 
@@ -474,8 +470,6 @@ void hdmi_cec_hpd_changed(unsigned int state)
 	u32 cec_stat0;
 	unsigned long flags;
 	struct hdmi_cec_priv *priv = &hdmi_cec_data;
-
-	pr_debug("function : %s (%d)\n", __func__, state);
 
 	link_status = state & 1;
 
@@ -555,8 +549,6 @@ static long hdmi_cec_ioctl(struct file *file, u_int cmd, u_long arg)
 	struct mxc_edid_cfg hdmi_edid_cfg;
 	struct hdmi_cec_priv *priv = file->private_data;
 
-	pr_debug("function : %s\n", __func__);
-
 	switch (cmd) {
 	case HDMICEC_IOC_SETLOGICALADDRESS:
 		mutex_lock(&priv->lock);
@@ -602,8 +594,6 @@ static int hdmi_cec_release(struct inode *inode, struct file *file)
 {
 	struct hdmi_cec_priv *priv = file->private_data;
 
-	pr_debug("function : %s\n", __func__);
-
 	mutex_lock(&priv->lock);
 	if (priv->open_count) {
 		priv->open_count = 0;
@@ -622,8 +612,6 @@ static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 {
 	unsigned int mask = 0;
 	struct hdmi_cec_priv *priv = file->private_data;
-
-	pr_debug("function : %s\n", __func__);
 
 	poll_wait(file, &rx_queue, wait);
 	poll_wait(file, &tx_queue, wait);

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -55,7 +55,7 @@
 #define MESSAGE_TYPE_CONNECTED		4
 #define MESSAGE_TYPE_SEND_SUCCESS	5
 
-#define CEC_TX_INPROGRESS		-1
+#define CEC_TX_INPROGRESS		0xffff0000
 #define CEC_TX_AVAIL			0
 
 #define	CEC_TX_RETRIES			3
@@ -80,7 +80,7 @@
 struct hdmi_cec_priv {
 	int receive_error;
 	int send_error;
-	int tx_answer;
+	u32 tx_answer;
 	u32 cec_stat0;
 	u8 logical_address;
 	u8 is_started;

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -182,11 +182,11 @@ static u32 get_hpd_stat(struct hdmi_cec_priv *hdmi_cec)
 
 static irqreturn_t mxc_hdmi_cec_isr(int irq, void *data)
 {
-	struct hdmi_cec_priv *hdmi_cec = data;
+	struct hdmi_cec_priv *priv = data;
 	unsigned long flags;
 	u8 cec_stat;
 
-	spin_lock_irqsave(&hdmi_cec->irq_lock, flags);
+	spin_lock_irqsave(&priv->irq_lock, flags);
 
 	hdmi_writeb(CEC_STAT0_MASK_ALL, HDMI_IH_MUTE_CEC_STAT0);
 
@@ -194,59 +194,59 @@ static irqreturn_t mxc_hdmi_cec_isr(int irq, void *data)
 	hdmi_writeb(cec_stat, HDMI_IH_CEC_STAT0);
 
 	if ((cec_stat & ~CEC_STAT0_MASK_DEFAULT) == 0) {
-		if (hdmi_cec->is_started)
+		if (priv->is_started)
 			hdmi_writeb(CEC_STAT0_MASK_DEFAULT, HDMI_IH_MUTE_CEC_STAT0);
-		spin_unlock_irqrestore(&hdmi_cec->irq_lock, flags);
+		spin_unlock_irqrestore(&priv->irq_lock, flags);
 		return IRQ_NONE;
 	}
 
 	pr_debug("HDMI-CEC: interrupt received\n");
 
-	hdmi_cec->cec_stat0 = cec_stat | get_hpd_stat(hdmi_cec);
-	schedule_work(&hdmi_cec->hdmi_cec_work);
+	priv->cec_stat0 = cec_stat | get_hpd_stat(priv);
+	schedule_work(&priv->hdmi_cec_work);
 
-	spin_unlock_irqrestore(&hdmi_cec->irq_lock, flags);
+	spin_unlock_irqrestore(&priv->irq_lock, flags);
 
 	return IRQ_HANDLED;
 }
 
-static void mxc_hdmi_cec_handle(u32 cec_stat)
+static void mxc_hdmi_cec_handle(struct hdmi_cec_priv *priv, u32 cec_stat)
 {
 	int i;
 	struct hdmi_cec_event *event;
 
-	if (!hdmi_cec_data.open_count)
+	if (!priv->open_count)
 		return;
 
 	/*HDMI cable connected: handle first*/
 	if (cec_stat & CEC_STAT0_EX_CONNECTED) {
 		pr_info("HDMI-CEC: link connected\n");
 
-		mutex_lock(&hdmi_cec_data.lock);
+		mutex_lock(&priv->lock);
 		event = alloc_event();
 		if (!event) {
-			mutex_unlock(&hdmi_cec_data.lock);
+			mutex_unlock(&priv->lock);
 			return;
 		}
 		event->event_type = MESSAGE_TYPE_CONNECTED;
 		list_add_tail(&event->list, &ev_pending);
-		mutex_unlock(&hdmi_cec_data.lock);
+		mutex_unlock(&priv->lock);
 
 		wake_up(&rx_queue);
 	}
 
 	/* The current transmission is successful (for initiator only). */
 	if (cec_stat & HDMI_IH_CEC_STAT0_DONE) {
-		hdmi_cec_data.tx_answer = cec_stat;
+		priv->tx_answer = cec_stat;
 		wake_up(&tx_queue);
 	}
 
 	/*EOM is detected so that the received data is ready in the receiver data buffer*/
 	if (cec_stat & HDMI_IH_CEC_STAT0_EOM) {
-		mutex_lock(&hdmi_cec_data.lock);
+		mutex_lock(&priv->lock);
 		event = alloc_event();
 		if (!event) {
-			mutex_unlock(&hdmi_cec_data.lock);
+			mutex_unlock(&priv->lock);
 			return;
 		}
 
@@ -254,7 +254,7 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 		if (!event->msg_len || event->msg_len > MAX_MESSAGE_LEN) {
 			pr_err("HDMI-CEC: Invalid CEC message length\n");
 			list_add_tail(&event->list, &ev_idle);
-			mutex_unlock(&hdmi_cec_data.lock);
+			mutex_unlock(&priv->lock);
 			return;
 		}
 
@@ -263,14 +263,14 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 			event->msg[i] = hdmi_readb(HDMI_CEC_RX_DATA0 + i);
 
 		list_add_tail(&event->list, &ev_pending);
-		mutex_unlock(&hdmi_cec_data.lock);
+		mutex_unlock(&priv->lock);
 
 		wake_up(&rx_queue);
 	}
 
 	/* An error is detected on cec line (for initiator only). */
 	if (cec_stat & HDMI_IH_CEC_STAT0_ERROR_INIT) {
-		hdmi_cec_data.tx_answer = cec_stat;
+		priv->tx_answer = cec_stat;
 		wake_up(&tx_queue);
 		return;
 	}
@@ -279,8 +279,8 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 	 * a broadcast message (for initiator only).
 	 */
 	if (cec_stat & HDMI_IH_CEC_STAT0_NACK) {
-		hdmi_cec_data.send_error++;
-		hdmi_cec_data.tx_answer = cec_stat;
+		priv->send_error++;
+		priv->tx_answer = cec_stat;
 		wake_up(&tx_queue);
 	}
 
@@ -288,22 +288,22 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 	 * Abnormal logic data bit error (for follower).
 	 */
 	if (cec_stat & HDMI_IH_CEC_STAT0_ERROR_FOLL) {
-		hdmi_cec_data.receive_error++;
+		priv->receive_error++;
 	}
 
 	/*HDMI cable disconnected: handle last*/
 	if (cec_stat & CEC_STAT0_EX_DISCONNECTED) {
 		pr_info("HDMI-CEC: link disconnected\n");
 
-		mutex_lock(&hdmi_cec_data.lock);
+		mutex_lock(&priv->lock);
 		event = alloc_event();
 		if (!event) {
-			mutex_unlock(&hdmi_cec_data.lock);
+			mutex_unlock(&priv->lock);
 			return;
 		}
 		event->event_type = MESSAGE_TYPE_DISCONNECTED;
 		list_add_tail(&event->list, &ev_pending);
-		mutex_unlock(&hdmi_cec_data.lock);
+		mutex_unlock(&priv->lock);
 
 		wake_up(&rx_queue);
 	}
@@ -312,32 +312,36 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 static void mxc_hdmi_cec_worker(struct work_struct *work)
 {
 	unsigned long flags;
+	struct hdmi_cec_priv *priv = &hdmi_cec_data;
 
-	mxc_hdmi_cec_handle(hdmi_cec_data.cec_stat0);
+	mxc_hdmi_cec_handle(priv, priv->cec_stat0);
 
-	if (hdmi_cec_data.cec_stat0 & HDMI_IH_CEC_STAT0_EOM)
+	if (priv->cec_stat0 & HDMI_IH_CEC_STAT0_EOM)
 		hdmi_writeb(0x0, HDMI_CEC_LOCK);
 
-	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
-	hdmi_cec_data.cec_stat0 = 0;
-	if (hdmi_cec_data.is_started)
+	spin_lock_irqsave(&priv->irq_lock, flags);
+	priv->cec_stat0 = 0;
+	if (priv->is_started)
 		hdmi_writeb(CEC_STAT0_MASK_DEFAULT, HDMI_IH_MUTE_CEC_STAT0);
-	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
+	spin_unlock_irqrestore(&priv->irq_lock, flags);
 }
 
 static int hdmi_cec_open(struct inode *inode, struct file *file)
 {
-	mutex_lock(&hdmi_cec_data.lock);
-	if (hdmi_cec_data.open_count) {
-		mutex_unlock(&hdmi_cec_data.lock);
+	struct hdmi_cec_priv *priv = &hdmi_cec_data;
+
+	mutex_lock(&priv->lock);
+	if (priv->open_count) {
+		mutex_unlock(&priv->lock);
 		return -EBUSY;
 	}
-	hdmi_cec_data.open_count = 1;
-	file->private_data = (void *)(&hdmi_cec_data);
-	hdmi_cec_data.tx_answer = CEC_TX_AVAIL;
-	hdmi_cec_data.logical_address = 15;
-	hdmi_cec_data.is_started = false;
-	mutex_unlock(&hdmi_cec_data.lock);
+	file->private_data = priv;
+
+	priv->tx_answer = CEC_TX_AVAIL;
+	priv->logical_address = 15;
+	priv->is_started = false;
+	priv->open_count = 1;
+	mutex_unlock(&priv->lock);
 	return 0;
 }
 
@@ -346,32 +350,33 @@ static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 {
 	ssize_t len = 0;
 	struct hdmi_cec_event *event;
+	struct hdmi_cec_priv *priv = file->private_data;
 
 	pr_debug("function : %s\n", __func__);
 
-	mutex_lock(&hdmi_cec_data.lock);
+	mutex_lock(&priv->lock);
 
-	if (!hdmi_cec_data.is_started)
+	if (!priv->is_started)
 		len = -EACCES;
 	else if (count < offsetof(struct hdmi_cec_event, padding))
 		len = -EINVAL;
 
 	if (len < 0) {
-		mutex_unlock(&hdmi_cec_data.lock);
+		mutex_unlock(&priv->lock);
 		return len;
 	}
 
 	if (list_empty(&ev_pending)) {
 		if (file->f_flags & O_NONBLOCK) {
-			mutex_unlock(&hdmi_cec_data.lock);
+			mutex_unlock(&priv->lock);
 			return -EAGAIN;
 		}
 
 		do {
-			mutex_unlock(&hdmi_cec_data.lock);
+			mutex_unlock(&priv->lock);
 			if (wait_event_interruptible(rx_queue, !list_empty(&ev_pending)))
 				return -ERESTARTSYS;
-			mutex_lock(&hdmi_cec_data.lock);
+			mutex_lock(&priv->lock);
 		} while (list_empty(&ev_pending));
 	}
 
@@ -381,7 +386,7 @@ static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 	if (copy_to_user(buf, event, len))
 		len = -EFAULT;
 	list_move_tail(&event->list, &ev_idle);
-	mutex_unlock(&hdmi_cec_data.lock);
+	mutex_unlock(&priv->lock);
 
 	return len;
 }
@@ -392,16 +397,17 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	int ret = 0;
 	u8 i, msg_len, val;
 	u8 msg[MAX_MESSAGE_LEN];
+	struct hdmi_cec_priv *priv = file->private_data;
 
 	pr_debug("function : %s\n", __func__);
 
-	mutex_lock(&hdmi_cec_data.lock);
+	mutex_lock(&priv->lock);
 
-	if (!hdmi_cec_data.is_started)
+	if (!priv->is_started)
 		ret = -EACCES;
-	else if (hdmi_cec_data.tx_answer != CEC_TX_AVAIL)
+	else if (priv->tx_answer != CEC_TX_AVAIL)
 		ret = -EAGAIN;
-	else if (hdmi_cec_data.link_status != 1)
+	else if (priv->link_status != 1)
 		ret = -EAGAIN;
 	else if (count > MAX_MESSAGE_LEN)
 		ret = -EINVAL;
@@ -409,12 +415,12 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 		ret = -EACCES;
 
 	if (ret) {
-		mutex_unlock(&hdmi_cec_data.lock);
+		mutex_unlock(&priv->lock);
 		return ret;
 	}
 
-	hdmi_cec_data.send_error = 0;
-	hdmi_cec_data.tx_answer = CEC_TX_INPROGRESS;
+	priv->send_error = 0;
+	priv->tx_answer = CEC_TX_INPROGRESS;
 
 	msg_len = count;
 	hdmi_writeb(msg_len, HDMI_CEC_TX_CNT);
@@ -424,40 +430,41 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	val |= 0x01;
 	hdmi_writeb(val, HDMI_CEC_CTRL);
 
-	mutex_unlock(&hdmi_cec_data.lock);
+	mutex_unlock(&priv->lock);
 
 	ret = wait_event_interruptible_timeout(
-		tx_queue, hdmi_cec_data.tx_answer != CEC_TX_INPROGRESS, HZ);
+		tx_queue, priv->tx_answer != CEC_TX_INPROGRESS, HZ);
 
 	if (ret < 0)
 		ret = -ERESTARTSYS;
-	else if (hdmi_cec_data.tx_answer & HDMI_IH_CEC_STAT0_DONE)
+	else if (priv->tx_answer & HDMI_IH_CEC_STAT0_DONE)
 		ret = msg_len;	/* msg sent, ACK received */
-	else if (hdmi_cec_data.tx_answer & HDMI_IH_CEC_STAT0_NACK)
+	else if (priv->tx_answer & HDMI_IH_CEC_STAT0_NACK)
 		ret = -EIO;	/* msg sent, NACK received */
 	else
 		ret = -EPIPE;	/* other error */
 
-	hdmi_cec_data.tx_answer = CEC_TX_AVAIL;
+	priv->tx_answer = CEC_TX_AVAIL;
 	return ret;
 }
 
 void hdmi_cec_hpd_changed(unsigned int state)
 {
+	u32 cec_stat0;
 	unsigned long flags;
-	u32           cec_stat0;
+	struct hdmi_cec_priv *priv = &hdmi_cec_data;
 
 	pr_debug("function : %s (%d)\n", __func__, state);
 
 	link_status = state & 1;
 
 	if (is_initialized) {
-		spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
-		cec_stat0 = get_hpd_stat(&hdmi_cec_data);
-		spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
+		spin_lock_irqsave(&priv->irq_lock, flags);
+		cec_stat0 = get_hpd_stat(priv);
+		spin_unlock_irqrestore(&priv->irq_lock, flags);
 
 		if (cec_stat0)
-			mxc_hdmi_cec_handle(cec_stat0);
+			mxc_hdmi_cec_handle(priv, cec_stat0);
 	}
 }
 EXPORT_SYMBOL(hdmi_cec_hpd_changed);
@@ -520,35 +527,35 @@ static void hdmi_cec_stop_device(void)
 	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
 }
 
-static long hdmi_cec_ioctl(struct file *file, u_int cmd,
-		     u_long arg)
+static long hdmi_cec_ioctl(struct file *file, u_int cmd, u_long arg)
 {
-	int ret = 0, status = 0;
-	u8 val = 0;
+	u8 val;
+	int ret = 0;
 	struct mxc_edid_cfg hdmi_edid_cfg;
+	struct hdmi_cec_priv *priv = file->private_data;
 
 	pr_debug("function : %s\n", __func__);
 
 	switch (cmd) {
 	case HDMICEC_IOC_SETLOGICALADDRESS:
-		mutex_lock(&hdmi_cec_data.lock);
-		if (!hdmi_cec_data.is_started) {
-			mutex_unlock(&hdmi_cec_data.lock);
+		mutex_lock(&priv->lock);
+		if (!priv->is_started) {
+			mutex_unlock(&priv->lock);
 			pr_err("Trying to set logical address while not started\n");
 			return -EACCES;
 		}
-		hdmi_cec_data.logical_address = (u8)arg;
-		if (hdmi_cec_data.logical_address <= 7) {
-			val = 1 << hdmi_cec_data.logical_address;
+		priv->logical_address = (u8)arg;
+		if (priv->logical_address <= 7) {
+			val = 1 << priv->logical_address;
 			hdmi_writeb(val, HDMI_CEC_ADDR_L);
 			hdmi_writeb(0, HDMI_CEC_ADDR_H);
-		} else if (hdmi_cec_data.logical_address > 7 && hdmi_cec_data.logical_address <= 15) {
-			val = 1 << (hdmi_cec_data.logical_address - 8);
+		} else if (priv->logical_address <= 15) {
+			val = 1 << (priv->logical_address - 8);
 			hdmi_writeb(val, HDMI_CEC_ADDR_H);
 			hdmi_writeb(0, HDMI_CEC_ADDR_L);
 		} else
 			ret = -EINVAL;
-		mutex_unlock(&hdmi_cec_data.lock);
+		mutex_unlock(&priv->lock);
 		break;
 	case HDMICEC_IOC_STARTDEVICE:
 		hdmi_cec_start_device();
@@ -558,10 +565,9 @@ static long hdmi_cec_ioctl(struct file *file, u_int cmd,
 		break;
 	case HDMICEC_IOC_GETPHYADDRESS:
 		hdmi_get_edid_cfg(&hdmi_edid_cfg);
-		status = copy_to_user((void __user *)arg,
-					 &hdmi_edid_cfg.physical_address,
-					 4*sizeof(u8));
-		if (status)
+		if (copy_to_user((void __user *)arg,
+				 &hdmi_edid_cfg.physical_address,
+				 4 * sizeof(u8)))
 			ret = -EFAULT;
 		break;
 	default:
@@ -573,18 +579,20 @@ static long hdmi_cec_ioctl(struct file *file, u_int cmd,
 
 static int hdmi_cec_release(struct inode *inode, struct file *file)
 {
+	struct hdmi_cec_priv *priv = file->private_data;
+
 	pr_debug("function : %s\n", __func__);
 
-	mutex_lock(&hdmi_cec_data.lock);
-	if (hdmi_cec_data.open_count) {
-		hdmi_cec_data.open_count = 0;
-		hdmi_cec_data.is_started = false;
-		hdmi_cec_data.logical_address = 15;
-		hdmi_cec_data.tx_answer = CEC_TX_AVAIL;
+	mutex_lock(&priv->lock);
+	if (priv->open_count) {
+		priv->open_count = 0;
+		priv->is_started = false;
+		priv->logical_address = 15;
+		priv->tx_answer = CEC_TX_AVAIL;
 
 		free_events();
 	}
-	mutex_unlock(&hdmi_cec_data.lock);
+	mutex_unlock(&priv->lock);
 
 	return 0;
 }
@@ -592,20 +600,21 @@ static int hdmi_cec_release(struct inode *inode, struct file *file)
 static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 {
 	unsigned int mask = 0;
+	struct hdmi_cec_priv *priv = file->private_data;
 
 	pr_debug("function : %s\n", __func__);
 
 	poll_wait(file, &rx_queue, wait);
 	poll_wait(file, &tx_queue, wait);
 
-	if (hdmi_cec_data.link_status == 1 &&
-	    hdmi_cec_data.tx_answer == CEC_TX_AVAIL)
+	if (priv->link_status == 1 &&
+	    priv->tx_answer == CEC_TX_AVAIL)
 		mask |= POLLOUT | POLLWRNORM;
 
-	mutex_lock(&hdmi_cec_data.lock);
+	mutex_lock(&priv->lock);
 	if (!list_empty(&ev_pending))
 		mask |= POLLIN | POLLRDNORM;
-	mutex_unlock(&hdmi_cec_data.lock);
+	mutex_unlock(&priv->lock);
 
 	return mask;
 }

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -329,6 +329,83 @@ static void mxc_hdmi_cec_worker(struct work_struct *work)
 	spin_unlock_irqrestore(&priv->irq_lock, flags);
 }
 
+void hdmi_cec_hpd_changed(unsigned int state)
+{
+	u32 cec_stat0;
+	unsigned long flags;
+	struct hdmi_cec_priv *priv = &hdmi_cec_data;
+
+	link_status = state & 1;
+
+	if (is_initialized) {
+		spin_lock_irqsave(&priv->irq_lock, flags);
+		cec_stat0 = get_hpd_stat(priv);
+		spin_unlock_irqrestore(&priv->irq_lock, flags);
+
+		if (cec_stat0)
+			mxc_hdmi_cec_handle(priv, cec_stat0);
+	}
+}
+EXPORT_SYMBOL(hdmi_cec_hpd_changed);
+
+static void hdmi_cec_start_device(void)
+{
+	u8 val;
+	unsigned long flags;
+
+	if (!is_initialized) {
+		want_start = 1;
+		return;
+	}
+
+	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
+
+	val = hdmi_readb(HDMI_MC_CLKDIS);
+	val &= ~HDMI_MC_CLKDIS_CECCLK_DISABLE;
+	hdmi_writeb(val, HDMI_MC_CLKDIS);
+	hdmi_writeb(0x02, HDMI_CEC_CTRL);
+	/* Force read unlock */
+	hdmi_writeb(0x0, HDMI_CEC_LOCK);
+
+	val = HDMI_IH_CEC_STAT0_ERROR_INIT | HDMI_IH_CEC_STAT0_NACK |
+	      HDMI_IH_CEC_STAT0_EOM | HDMI_IH_CEC_STAT0_DONE;
+	hdmi_writeb(val, HDMI_CEC_POLARITY);
+
+	val = CEC_STAT0_MASK_DEFAULT;
+	hdmi_writeb(val, HDMI_CEC_MASK);
+	hdmi_writeb(val, HDMI_IH_MUTE_CEC_STAT0);
+	hdmi_cec_data.link_status = link_status;
+	hdmi_cec_data.is_started = true;
+
+	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
+}
+
+static void hdmi_cec_stop_device(void)
+{
+	u8 val;
+	unsigned long flags;
+
+	if (!is_initialized) {
+		want_start = 0;
+		return;
+	}
+
+	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
+
+	hdmi_cec_data.is_started = false;
+	hdmi_writeb(0x10, HDMI_CEC_CTRL);
+	val = CEC_STAT0_MASK_ALL;
+	hdmi_writeb(val, HDMI_CEC_MASK);
+	hdmi_writeb(val, HDMI_IH_MUTE_CEC_STAT0);
+
+	hdmi_writeb(0x0, HDMI_CEC_POLARITY);
+	val = hdmi_readb(HDMI_MC_CLKDIS);
+	val |= HDMI_MC_CLKDIS_CECCLK_DISABLE;
+	hdmi_writeb(val, HDMI_MC_CLKDIS);
+
+	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
+}
+
 static int hdmi_cec_open(struct inode *inode, struct file *file)
 {
 	struct hdmi_cec_priv *priv = &hdmi_cec_data;
@@ -345,6 +422,24 @@ static int hdmi_cec_open(struct inode *inode, struct file *file)
 	priv->is_started = false;
 	priv->open_count = 1;
 	mutex_unlock(&priv->lock);
+	return 0;
+}
+
+static int hdmi_cec_release(struct inode *inode, struct file *file)
+{
+	struct hdmi_cec_priv *priv = file->private_data;
+
+	mutex_lock(&priv->lock);
+	if (priv->open_count) {
+		priv->open_count = 0;
+		priv->is_started = false;
+		priv->logical_address = 15;
+		priv->tx_answer = CEC_TX_AVAIL;
+
+		free_events();
+	}
+	mutex_unlock(&priv->lock);
+
 	return 0;
 }
 
@@ -465,81 +560,24 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	return ret;
 }
 
-void hdmi_cec_hpd_changed(unsigned int state)
+static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 {
-	u32 cec_stat0;
-	unsigned long flags;
-	struct hdmi_cec_priv *priv = &hdmi_cec_data;
+	unsigned int mask = 0;
+	struct hdmi_cec_priv *priv = file->private_data;
 
-	link_status = state & 1;
+	poll_wait(file, &rx_queue, wait);
+	poll_wait(file, &tx_queue, wait);
 
-	if (is_initialized) {
-		spin_lock_irqsave(&priv->irq_lock, flags);
-		cec_stat0 = get_hpd_stat(priv);
-		spin_unlock_irqrestore(&priv->irq_lock, flags);
+	if (priv->link_status == 0 ||
+	    priv->tx_answer == CEC_TX_AVAIL)
+		mask |= POLLOUT | POLLWRNORM;
 
-		if (cec_stat0)
-			mxc_hdmi_cec_handle(priv, cec_stat0);
-	}
-}
-EXPORT_SYMBOL(hdmi_cec_hpd_changed);
+	mutex_lock(&priv->lock);
+	if (!list_empty(&ev_pending))
+		mask |= POLLIN | POLLRDNORM;
+	mutex_unlock(&priv->lock);
 
-static void hdmi_cec_start_device(void)
-{
-	u8 val;
-	unsigned long flags;
-
-	if (!is_initialized) {
-		want_start = 1;
-		return;
-	}
-
-	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
-
-	val = hdmi_readb(HDMI_MC_CLKDIS);
-	val &= ~HDMI_MC_CLKDIS_CECCLK_DISABLE;
-	hdmi_writeb(val, HDMI_MC_CLKDIS);
-	hdmi_writeb(0x02, HDMI_CEC_CTRL);
-	/* Force read unlock */
-	hdmi_writeb(0x0, HDMI_CEC_LOCK);
-
-	val = HDMI_IH_CEC_STAT0_ERROR_INIT | HDMI_IH_CEC_STAT0_NACK |
-	      HDMI_IH_CEC_STAT0_EOM | HDMI_IH_CEC_STAT0_DONE;
-	hdmi_writeb(val, HDMI_CEC_POLARITY);
-
-	val = CEC_STAT0_MASK_DEFAULT;
-	hdmi_writeb(val, HDMI_CEC_MASK);
-	hdmi_writeb(val, HDMI_IH_MUTE_CEC_STAT0);
-	hdmi_cec_data.link_status = link_status;
-	hdmi_cec_data.is_started = true;
-
-	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
-}
-
-static void hdmi_cec_stop_device(void)
-{
-	u8 val;
-	unsigned long flags;
-
-	if (!is_initialized) {
-		want_start = 0;
-		return;
-	}
-
-	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
-
-	hdmi_cec_data.is_started = false;
-	hdmi_writeb(0x10, HDMI_CEC_CTRL);
-	val = CEC_STAT0_MASK_ALL;
-	hdmi_writeb(val, HDMI_CEC_MASK);
-	hdmi_writeb(val, HDMI_IH_MUTE_CEC_STAT0);
-
-	hdmi_writeb(0x0, HDMI_CEC_POLARITY);
-	val = hdmi_readb(HDMI_MC_CLKDIS);
-	val |= HDMI_MC_CLKDIS_CECCLK_DISABLE;
-	hdmi_writeb(val, HDMI_MC_CLKDIS);
-
-	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
+	return mask;
 }
 
 static long hdmi_cec_ioctl(struct file *file, u_int cmd, u_long arg)
@@ -588,44 +626,6 @@ static long hdmi_cec_ioctl(struct file *file, u_int cmd, u_long arg)
 		break;
 	}
     return ret;
-}
-
-static int hdmi_cec_release(struct inode *inode, struct file *file)
-{
-	struct hdmi_cec_priv *priv = file->private_data;
-
-	mutex_lock(&priv->lock);
-	if (priv->open_count) {
-		priv->open_count = 0;
-		priv->is_started = false;
-		priv->logical_address = 15;
-		priv->tx_answer = CEC_TX_AVAIL;
-
-		free_events();
-	}
-	mutex_unlock(&priv->lock);
-
-	return 0;
-}
-
-static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
-{
-	unsigned int mask = 0;
-	struct hdmi_cec_priv *priv = file->private_data;
-
-	poll_wait(file, &rx_queue, wait);
-	poll_wait(file, &tx_queue, wait);
-
-	if (priv->link_status == 0 ||
-	    priv->tx_answer == CEC_TX_AVAIL)
-		mask |= POLLOUT | POLLWRNORM;
-
-	mutex_lock(&priv->lock);
-	if (!list_empty(&ev_pending))
-		mask |= POLLIN | POLLRDNORM;
-	mutex_unlock(&priv->lock);
-
-	return mask;
 }
 
 

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -47,24 +47,22 @@
 #include "mxc_hdmi-cec.h"
 
 
-#define MAX_MESSAGE_LEN		17
+#define MAX_MESSAGE_LEN			17
 
-#define MESSAGE_TYPE_RECEIVE_SUCCESS		1
+#define MESSAGE_TYPE_RECEIVE_SUCCESS	1
 #define MESSAGE_TYPE_NOACK		2
-#define MESSAGE_TYPE_DISCONNECTED		3
+#define MESSAGE_TYPE_DISCONNECTED	3
 #define MESSAGE_TYPE_CONNECTED		4
-#define MESSAGE_TYPE_SEND_SUCCESS		5
+#define MESSAGE_TYPE_SEND_SUCCESS	5
 
-#define CEC_TX_INPROGRESS -1
-#define CEC_TX_AVAIL 0
+#define CEC_TX_INPROGRESS		-1
+#define CEC_TX_AVAIL			0
 
 struct hdmi_cec_priv {
 	int  receive_error;
 	int  send_error;
 	u8 Logical_address;
 	bool cec_state;
-	u8 last_msg[MAX_MESSAGE_LEN];
-	u8 msg_len;
 	int tx_answer;
 	u16 latest_cec_stat;
 	u8 link_status;
@@ -234,11 +232,6 @@ static void mxc_hdmi_cec_worker(struct work_struct *work)
 	hdmi_writeb(val, HDMI_IH_MUTE_CEC_STAT0);
 }
 
-/*!
- * @brief open function for cec file operation
- *
- * @return  0 on success or negative error code on error
- */
 static int hdmi_cec_open(struct inode *inode, struct file *filp)
 {
 	mutex_lock(&hdmi_cec_data.lock);
@@ -258,10 +251,9 @@ static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 			    loff_t *ppos)
 {
 	struct hdmi_cec_event *event = NULL;
+
 	pr_debug("function : %s\n", __func__);
 
-	if (!open_count)
-		return -ENODEV;
 	mutex_lock(&hdmi_cec_data.lock);
 	if (false == hdmi_cec_data.cec_state) {
 		mutex_unlock(&hdmi_cec_data.lock);
@@ -303,8 +295,6 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 
 	pr_debug("function : %s\n", __func__);
 
-	if (!open_count)
-		return -ENODEV;
 	mutex_lock(&hdmi_cec_data.lock);
 	if (false == hdmi_cec_data.cec_state) {
 		mutex_unlock(&hdmi_cec_data.lock);
@@ -332,8 +322,6 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	val = hdmi_readb(HDMI_CEC_CTRL);
 	val |= 0x01;
 	hdmi_writeb(val, HDMI_CEC_CTRL);
-	memcpy(hdmi_cec_data.last_msg, msg, msg_len);
-	hdmi_cec_data.msg_len = msg_len;
 	mutex_unlock(&hdmi_cec_data.lock);
 
 	ret = wait_event_interruptible_timeout(tx_cec_queue, hdmi_cec_data.tx_answer != CEC_TX_INPROGRESS, HZ);
@@ -347,9 +335,9 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 		/* msg correctly sent */
 		ret = msg_len;
 	else
-		ret =  -EIO;
+		ret = -EIO;
 
-	tx_out:
+tx_out:
 	hdmi_cec_data.tx_answer = CEC_TX_AVAIL;
 	return ret;
 }
@@ -373,20 +361,15 @@ static void hdmi_stop_device(void)
 	mutex_unlock(&hdmi_cec_data.lock);
 }
 
-/*!
- * @brief IO ctrl function for vpu file operation
- * @param cmd IO ctrl command
- * @return  0 on success or negative error code on error
- */
 static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
 		     u_long arg)
 {
 	int ret = 0, status = 0;
 	u8 val = 0;
 	struct mxc_edid_cfg hdmi_edid_cfg;
+
 	pr_debug("function : %s\n", __func__);
-	if (!open_count)
-		return -ENODEV;
+
 	switch (cmd) {
 	case HDMICEC_IOC_SETLOGICALADDRESS:
 		mutex_lock(&hdmi_cec_data.lock);
@@ -443,13 +426,12 @@ static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
     return ret;
 }
 
-/*!
- * @brief Release function for vpu file operation
- * @return  0 on success or negative error code on error
- */
 static int hdmi_cec_release(struct inode *inode, struct file *filp)
 {
 	struct hdmi_cec_event *event, *tmp_event;
+
+	pr_debug("function : %s\n", __func__);
+
 	mutex_lock(&hdmi_cec_data.lock);
 	if (open_count) {
 		open_count = 0;
@@ -479,7 +461,7 @@ static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 	if (hdmi_cec_data.tx_answer == CEC_TX_AVAIL)
 		mask =  (POLLOUT | POLLWRNORM);
 	if (!list_empty(&head))
-			mask |= (POLLIN | POLLRDNORM);
+		mask |= (POLLIN | POLLRDNORM);
 	mutex_unlock(&hdmi_cec_data.lock);
 	return mask;
 }
@@ -505,14 +487,14 @@ static int hdmi_cec_dev_probe(struct platform_device *pdev)
 
 	hdmi_cec_major = register_chrdev(hdmi_cec_major, "mxc_hdmi_cec", &hdmi_cec_fops);
 	if (hdmi_cec_major < 0) {
-		dev_err(&pdev->dev, "hdmi_cec: unable to get a major for HDMI CEC\n");
+		dev_err(&pdev->dev, "Unable to get a major for HDMI CEC\n");
 		err = -EBUSY;
 		goto out;
 	}
 
 	res = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
 	if (unlikely(res == NULL)) {
-		dev_err(&pdev->dev, "hdmi_cec:No HDMI irq line provided\n");
+		dev_err(&pdev->dev, "No HDMI irq line provided\n");
 		goto err_out_chrdev;
 	}
 	spin_lock_init(&hdmi_cec_data.irq_lock);
@@ -522,7 +504,7 @@ static int hdmi_cec_dev_probe(struct platform_device *pdev)
 	err = devm_request_irq(&pdev->dev, irq, mxc_hdmi_cec_isr, IRQF_SHARED,
 			dev_name(&pdev->dev), &hdmi_cec_data);
 	if (err < 0) {
-		dev_err(&pdev->dev, "hdmi_cec:Unable to request irq: %d\n", err);
+		dev_err(&pdev->dev, "Unable to request irq: %d\n", err);
 		goto err_out_chrdev;
 	}
 
@@ -532,8 +514,8 @@ static int hdmi_cec_dev_probe(struct platform_device *pdev)
 		goto err_out_chrdev;
 	}
 
-	temp_class = device_create(hdmi_cec_class, NULL, MKDEV(hdmi_cec_major, 0),
-														 NULL, "mxc_hdmi_cec");
+	temp_class = device_create(hdmi_cec_class, NULL,
+				   MKDEV(hdmi_cec_major, 0), NULL, "mxc_hdmi_cec");
 	if (IS_ERR(temp_class)) {
 		err = PTR_ERR(temp_class);
 		goto err_out_class;
@@ -541,7 +523,7 @@ static int hdmi_cec_dev_probe(struct platform_device *pdev)
 
 	pinctrl = devm_pinctrl_get_select_default(&pdev->dev);
 	if (IS_ERR(pinctrl)) {
-		dev_err(&pdev->dev, "can't get/select CEC pinctrl\n");
+		dev_err(&pdev->dev, "Can't get/select CEC pinctrl\n");
 		goto err_out_class;
 	}
 
@@ -569,14 +551,13 @@ out:
 
 static int hdmi_cec_dev_remove(struct platform_device *pdev)
 {
-	if (hdmi_cec_data.cec_state)
-		hdmi_stop_device();
-	if (hdmi_cec_major > 0) {
-		device_destroy(hdmi_cec_class, MKDEV(hdmi_cec_major, 0));
-		class_destroy(hdmi_cec_class);
-		unregister_chrdev(hdmi_cec_major, "mxc_hdmi_cec");
-		hdmi_cec_major = 0;
-}
+	hdmi_stop_device();
+
+	device_destroy(hdmi_cec_class, MKDEV(hdmi_cec_major, 0));
+	class_destroy(hdmi_cec_class);
+	unregister_chrdev(hdmi_cec_major, "mxc_hdmi_cec");
+	hdmi_cec_major = 0;
+
 	return 0;
 }
 
@@ -590,9 +571,9 @@ static struct platform_driver mxc_hdmi_cec_driver = {
 	.probe = hdmi_cec_dev_probe,
 	.remove = hdmi_cec_dev_remove,
 	.driver = {
-		   .name = "mxc_hdmi_cec",
-		.of_match_table	= imx_hdmi_cec_match,
-		   },
+		.name = "mxc_hdmi_cec",
+		.of_match_table = imx_hdmi_cec_match,
+	},
 };
 
 module_platform_driver(mxc_hdmi_cec_driver);

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -471,11 +471,18 @@ static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
  */
 static int hdmi_cec_release(struct inode *inode, struct file *filp)
 {
+	struct hdmi_cec_event *event, *tmp_event;
 	mutex_lock(&hdmi_cec_data.lock);
 	if (open_count) {
 		open_count = 0;
 		hdmi_cec_data.cec_state = false;
 		hdmi_cec_data.Logical_address = 15;
+
+		/* Flush eventual events which have not been read by user space */
+		list_for_each_entry_safe(event, tmp_event, &head, list) {
+			list_del(&event->list);
+			vfree(event);
+		}
 	}
 	mutex_unlock(&hdmi_cec_data.lock);
 

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -75,13 +75,14 @@
 				 HDMI_IH_CEC_STAT0_ARB_LOST)
 
 struct hdmi_cec_priv {
-	int  receive_error;
-	int  send_error;
-	u8 Logical_address;
-	u8 cec_state;
+	int receive_error;
+	int send_error;
 	int tx_answer;
 	u32 cec_stat0;
+	u8 logical_address;
+	u8 is_started;
 	u8 link_status;
+	u8 open_count;
 	spinlock_t irq_lock;
 	struct work_struct hdmi_cec_work;
 	struct mutex lock;
@@ -95,19 +96,18 @@ struct hdmi_cec_event {
 };
 
 
-static LIST_HEAD(head);
+static LIST_HEAD(ev_pending);
 
 static int hdmi_cec_irq;
 static int hdmi_cec_major;
 static struct class *hdmi_cec_class;
 static struct hdmi_cec_priv hdmi_cec_data;
-static u8 open_count;
 static u8 want_start;
 static u8 link_status;
 static u8 is_initialized;
 
-static wait_queue_head_t hdmi_cec_queue;
-static wait_queue_head_t tx_cec_queue;
+static wait_queue_head_t rx_queue;
+static wait_queue_head_t tx_queue;
 
 static u32 get_hpd_stat(struct hdmi_cec_priv *hdmi_cec)
 {
@@ -138,7 +138,7 @@ static irqreturn_t mxc_hdmi_cec_isr(int irq, void *data)
 	hdmi_writeb(cec_stat, HDMI_IH_CEC_STAT0);
 
 	if ((cec_stat & ~CEC_STAT0_MASK_DEFAULT) == 0) {
-		if (hdmi_cec->cec_state)
+		if (hdmi_cec->is_started)
 			hdmi_writeb(CEC_STAT0_MASK_DEFAULT, HDMI_IH_MUTE_CEC_STAT0);
 		spin_unlock_irqrestore(&hdmi_cec->irq_lock, flags);
 		return IRQ_NONE;
@@ -159,13 +159,13 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 	u8 i = 0;
 	struct hdmi_cec_event *event = NULL;
 
-	if (!open_count)
+	if (!hdmi_cec_data.open_count)
 		return;
 
 	/* The current transmission is successful (for initiator only). */
 	if (cec_stat & HDMI_IH_CEC_STAT0_DONE) {
 		hdmi_cec_data.tx_answer = cec_stat;
-		wake_up(&tx_cec_queue);
+		wake_up(&tx_queue);
 	}
 
 	/*EOM is detected so that the received data is ready in the receiver data buffer*/
@@ -187,15 +187,15 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 			event->msg[i] = hdmi_readb(HDMI_CEC_RX_DATA0+i);
 		hdmi_writeb(0x0, HDMI_CEC_LOCK);
 		mutex_lock(&hdmi_cec_data.lock);
-		list_add_tail(&event->list, &head);
+		list_add_tail(&event->list, &ev_pending);
 		mutex_unlock(&hdmi_cec_data.lock);
-		wake_up(&hdmi_cec_queue);
+		wake_up(&rx_queue);
 	}
 
 	/* An error is detected on cec line (for initiator only). */
 	if (cec_stat & HDMI_IH_CEC_STAT0_ERROR_INIT) {
 		hdmi_cec_data.tx_answer = cec_stat;
-		wake_up(&tx_cec_queue);
+		wake_up(&tx_queue);
 		return;
 	}
 	/* A frame is not acknowledged in a directly addressed message.
@@ -205,7 +205,7 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 	if (cec_stat & HDMI_IH_CEC_STAT0_NACK) {
 		hdmi_cec_data.send_error++;
 		hdmi_cec_data.tx_answer = cec_stat;
-		wake_up(&tx_cec_queue);
+		wake_up(&tx_queue);
 	}
 
 	/* An error is notified by a follower.
@@ -227,9 +227,9 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 		memset(event, 0, sizeof(struct hdmi_cec_event));
 		event->event_type = MESSAGE_TYPE_CONNECTED;
 		mutex_lock(&hdmi_cec_data.lock);
-		list_add_tail(&event->list, &head);
+		list_add_tail(&event->list, &ev_pending);
 		mutex_unlock(&hdmi_cec_data.lock);
-		wake_up(&hdmi_cec_queue);
+		wake_up(&rx_queue);
 	}
 	/*HDMI cable disconnected*/
 	if (cec_stat & CEC_STAT0_EX_DISCONNECTED) {
@@ -242,9 +242,9 @@ static void mxc_hdmi_cec_handle(u32 cec_stat)
 		memset(event, 0, sizeof(struct hdmi_cec_event));
 		event->event_type = MESSAGE_TYPE_DISCONNECTED;
 		mutex_lock(&hdmi_cec_data.lock);
-		list_add_tail(&event->list, &head);
+		list_add_tail(&event->list, &ev_pending);
 		mutex_unlock(&hdmi_cec_data.lock);
-		wake_up(&hdmi_cec_queue);
+		wake_up(&rx_queue);
 	}
 }
 
@@ -256,22 +256,22 @@ static void mxc_hdmi_cec_worker(struct work_struct *work)
 
 	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
 	hdmi_cec_data.cec_stat0 = 0;
-	if (hdmi_cec_data.cec_state)
+	if (hdmi_cec_data.is_started)
 		hdmi_writeb(CEC_STAT0_MASK_DEFAULT, HDMI_IH_MUTE_CEC_STAT0);
 	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
 }
 
-static int hdmi_cec_open(struct inode *inode, struct file *filp)
+static int hdmi_cec_open(struct inode *inode, struct file *file)
 {
 	mutex_lock(&hdmi_cec_data.lock);
-	if (open_count) {
+	if (hdmi_cec_data.open_count) {
 		mutex_unlock(&hdmi_cec_data.lock);
 		return -EBUSY;
 	}
-	open_count = 1;
-	filp->private_data = (void *)(&hdmi_cec_data);
-	hdmi_cec_data.Logical_address = 15;
-	hdmi_cec_data.cec_state = false;
+	hdmi_cec_data.open_count = 1;
+	file->private_data = (void *)(&hdmi_cec_data);
+	hdmi_cec_data.logical_address = 15;
+	hdmi_cec_data.is_started = false;
 	mutex_unlock(&hdmi_cec_data.lock);
 	return 0;
 }
@@ -284,26 +284,26 @@ static ssize_t hdmi_cec_read(struct file *file, char __user *buf, size_t count,
 	pr_debug("function : %s\n", __func__);
 
 	mutex_lock(&hdmi_cec_data.lock);
-	if (!hdmi_cec_data.cec_state) {
+	if (!hdmi_cec_data.is_started) {
 		mutex_unlock(&hdmi_cec_data.lock);
 		return -EACCES;
 	}
 
-	if (list_empty(&head)) {
+	if (list_empty(&ev_pending)) {
 		if (file->f_flags & O_NONBLOCK) {
 			mutex_unlock(&hdmi_cec_data.lock);
 			return -EAGAIN;
 		} else {
 			do {
 				mutex_unlock(&hdmi_cec_data.lock);
-				if (wait_event_interruptible(hdmi_cec_queue, (!list_empty(&head))))
+				if (wait_event_interruptible(rx_queue, !list_empty(&ev_pending)))
 					return -ERESTARTSYS;
 				mutex_lock(&hdmi_cec_data.lock);
-			} while (list_empty(&head));
+			} while (list_empty(&ev_pending));
 		}
 	}
 
-	event = list_first_entry(&head, struct hdmi_cec_event, list);
+	event = list_first_entry(&ev_pending, struct hdmi_cec_event, list);
 	list_del(&event->list);
 	mutex_unlock(&hdmi_cec_data.lock);
 	if (copy_to_user(buf, event,
@@ -320,19 +320,19 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 {
 	int ret = 0;
 	u8 i, msg_len, val;
-	u8 msg[MAX_MESSAGE_LEN] = { 0 };
+	u8 msg[MAX_MESSAGE_LEN];
 
 	pr_debug("function : %s\n", __func__);
 
 	mutex_lock(&hdmi_cec_data.lock);
 
-	if (!hdmi_cec_data.cec_state)
+	if (!hdmi_cec_data.is_started)
 		ret = -EACCES;
 	else if (hdmi_cec_data.tx_answer != CEC_TX_AVAIL)
 		ret = -EBUSY;
 	else if (count > MAX_MESSAGE_LEN)
 		ret = -EINVAL;
-	else if (copy_from_user(&msg, buf, count))
+	else if (copy_from_user(msg, buf, count))
 		ret = -EACCES;
 
 	if (ret) {
@@ -354,7 +354,7 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	mutex_unlock(&hdmi_cec_data.lock);
 
 	ret = wait_event_interruptible_timeout(
-		tx_cec_queue, hdmi_cec_data.tx_answer != CEC_TX_INPROGRESS, HZ);
+		tx_queue, hdmi_cec_data.tx_answer != CEC_TX_INPROGRESS, HZ);
 
 	if (ret < 0) {
 		ret = -ERESTARTSYS;
@@ -419,7 +419,7 @@ static void hdmi_cec_start_device(void)
 	hdmi_writeb(val, HDMI_CEC_MASK);
 	hdmi_writeb(val, HDMI_IH_MUTE_CEC_STAT0);
 	hdmi_cec_data.link_status = link_status;
-	hdmi_cec_data.cec_state = true;
+	hdmi_cec_data.is_started = true;
 
 	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
 }
@@ -436,7 +436,7 @@ static void hdmi_cec_stop_device(void)
 
 	spin_lock_irqsave(&hdmi_cec_data.irq_lock, flags);
 
-	hdmi_cec_data.cec_state = false;
+	hdmi_cec_data.is_started = false;
 	hdmi_writeb(0x10, HDMI_CEC_CTRL);
 	val = CEC_STAT0_MASK_ALL;
 	hdmi_writeb(val, HDMI_CEC_MASK);
@@ -450,7 +450,7 @@ static void hdmi_cec_stop_device(void)
 	spin_unlock_irqrestore(&hdmi_cec_data.irq_lock, flags);
 }
 
-static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
+static long hdmi_cec_ioctl(struct file *file, u_int cmd,
 		     u_long arg)
 {
 	int ret = 0, status = 0;
@@ -462,18 +462,18 @@ static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
 	switch (cmd) {
 	case HDMICEC_IOC_SETLOGICALADDRESS:
 		mutex_lock(&hdmi_cec_data.lock);
-		if (!hdmi_cec_data.cec_state) {
+		if (!hdmi_cec_data.is_started) {
 			mutex_unlock(&hdmi_cec_data.lock);
 			pr_err("Trying to set logical address while not started\n");
 			return -EACCES;
 		}
-		hdmi_cec_data.Logical_address = (u8)arg;
-		if (hdmi_cec_data.Logical_address <= 7) {
-			val = 1 << hdmi_cec_data.Logical_address;
+		hdmi_cec_data.logical_address = (u8)arg;
+		if (hdmi_cec_data.logical_address <= 7) {
+			val = 1 << hdmi_cec_data.logical_address;
 			hdmi_writeb(val, HDMI_CEC_ADDR_L);
 			hdmi_writeb(0, HDMI_CEC_ADDR_H);
-		} else if (hdmi_cec_data.Logical_address > 7 && hdmi_cec_data.Logical_address <= 15) {
-			val = 1 << (hdmi_cec_data.Logical_address - 8);
+		} else if (hdmi_cec_data.logical_address > 7 && hdmi_cec_data.logical_address <= 15) {
+			val = 1 << (hdmi_cec_data.logical_address - 8);
 			hdmi_writeb(val, HDMI_CEC_ADDR_H);
 			hdmi_writeb(0, HDMI_CEC_ADDR_L);
 		} else
@@ -501,20 +501,20 @@ static long hdmi_cec_ioctl(struct file *filp, u_int cmd,
     return ret;
 }
 
-static int hdmi_cec_release(struct inode *inode, struct file *filp)
+static int hdmi_cec_release(struct inode *inode, struct file *file)
 {
 	struct hdmi_cec_event *event, *tmp_event;
 
 	pr_debug("function : %s\n", __func__);
 
 	mutex_lock(&hdmi_cec_data.lock);
-	if (open_count) {
-		open_count = 0;
-		hdmi_cec_data.cec_state = false;
-		hdmi_cec_data.Logical_address = 15;
+	if (hdmi_cec_data.open_count) {
+		hdmi_cec_data.open_count = 0;
+		hdmi_cec_data.is_started = false;
+		hdmi_cec_data.logical_address = 15;
 
 		/* Flush eventual events which have not been read by user space */
-		list_for_each_entry_safe(event, tmp_event, &head, list) {
+		list_for_each_entry_safe(event, tmp_event, &ev_pending, list) {
 			list_del(&event->list);
 			vfree(event);
 		}
@@ -530,12 +530,12 @@ static unsigned int hdmi_cec_poll(struct file *file, poll_table *wait)
 
 	pr_debug("function : %s\n", __func__);
 
-	poll_wait(file, &hdmi_cec_queue, wait);
+	poll_wait(file, &rx_queue, wait);
 
 	mutex_lock(&hdmi_cec_data.lock);
 	if (hdmi_cec_data.tx_answer == CEC_TX_AVAIL)
 		mask =  (POLLOUT | POLLWRNORM);
-	if (!list_empty(&head))
+	if (!list_empty(&ev_pending))
 		mask |= (POLLIN | POLLRDNORM);
 	mutex_unlock(&hdmi_cec_data.lock);
 	return mask;
@@ -592,15 +592,15 @@ static int hdmi_cec_dev_probe(struct platform_device *pdev)
 		goto err_out_class;
 	}
 
-	INIT_LIST_HEAD(&head);
+	INIT_LIST_HEAD(&ev_pending);
 
-	init_waitqueue_head(&hdmi_cec_queue);
-	init_waitqueue_head(&tx_cec_queue);
+	init_waitqueue_head(&rx_queue);
+	init_waitqueue_head(&tx_queue);
 
 	mutex_init(&hdmi_cec_data.lock);
 	spin_lock_init(&hdmi_cec_data.irq_lock);
 
-	hdmi_cec_data.Logical_address = 15;
+	hdmi_cec_data.logical_address = 15;
 	hdmi_cec_data.tx_answer = CEC_TX_AVAIL;
 	INIT_WORK(&hdmi_cec_data.hdmi_cec_work, mxc_hdmi_cec_worker);
 

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -58,6 +58,9 @@
 #define CEC_TX_INPROGRESS		-1
 #define CEC_TX_AVAIL			0
 
+#define	CEC_TX_RETRIES			3
+
+
 /* These flags must not collide with HDMI_IH_CEC_STAT0_xxxx */
 #define	CEC_STAT0_EX_CONNECTED		0x0100
 #define	CEC_STAT0_EX_DISCONNECTED	0x0200
@@ -213,6 +216,7 @@ static irqreturn_t mxc_hdmi_cec_isr(int irq, void *data)
 static void mxc_hdmi_cec_handle(struct hdmi_cec_priv *priv, u32 cec_stat)
 {
 	int i;
+	u8 val;
 	struct hdmi_cec_event *event;
 
 	if (!priv->open_count)
@@ -269,19 +273,18 @@ static void mxc_hdmi_cec_handle(struct hdmi_cec_priv *priv, u32 cec_stat)
 	}
 
 	/* An error is detected on cec line (for initiator only). */
-	if (cec_stat & HDMI_IH_CEC_STAT0_ERROR_INIT) {
-		priv->tx_answer = cec_stat;
-		wake_up(&tx_queue);
-		return;
-	}
 	/* A frame is not acknowledged in a directly addressed message.
 	 * Or a frame is negatively acknowledged in
 	 * a broadcast message (for initiator only).
 	 */
-	if (cec_stat & HDMI_IH_CEC_STAT0_NACK) {
-		priv->send_error++;
-		priv->tx_answer = cec_stat;
-		wake_up(&tx_queue);
+	if (cec_stat & (HDMI_IH_CEC_STAT0_ERROR_INIT | HDMI_IH_CEC_STAT0_NACK)) {
+		if (++priv->send_error < CEC_TX_RETRIES) {
+			val = hdmi_readb(HDMI_CEC_CTRL) & ~0x07;
+			hdmi_writeb(val | 0x01, HDMI_CEC_CTRL);
+		} else {
+			priv->tx_answer = cec_stat;
+			wake_up(&tx_queue);
+		}
 	}
 
 	/* An error is notified by a follower.
@@ -426,10 +429,9 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	msg_len = count;
 	hdmi_writeb(msg_len, HDMI_CEC_TX_CNT);
 	for (i = 0; i < msg_len; i++)
-		hdmi_writeb(msg[i], HDMI_CEC_TX_DATA0+i);
-	val = hdmi_readb(HDMI_CEC_CTRL);
-	val |= 0x01;
-	hdmi_writeb(val, HDMI_CEC_CTRL);
+		hdmi_writeb(msg[i], HDMI_CEC_TX_DATA0 + i);
+	val = hdmi_readb(HDMI_CEC_CTRL) & ~0x07;
+	hdmi_writeb(val | 0x03, HDMI_CEC_CTRL);
 
 	mutex_unlock(&priv->lock);
 

--- a/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
+++ b/drivers/mxc/hdmi-cec/mxc_hdmi-cec.c
@@ -397,6 +397,7 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 	int ret = 0;
 	u8 i, msg_len, val;
 	u8 msg[MAX_MESSAGE_LEN];
+	struct hdmi_cec_event *event;
 	struct hdmi_cec_priv *priv = file->private_data;
 
 	pr_debug("function : %s\n", __func__);
@@ -445,6 +446,24 @@ static ssize_t hdmi_cec_write(struct file *file, const char __user *buf,
 		ret = -EPIPE;	/* other error */
 
 	priv->tx_answer = CEC_TX_AVAIL;
+
+	if (ret >= 0 || ret == -EIO) {
+		mutex_lock(&priv->lock);
+
+		event = alloc_event();
+		if (event) {
+			event->event_type = (ret == -EIO) ?
+				MESSAGE_TYPE_NOACK : MESSAGE_TYPE_SEND_SUCCESS;
+			event->msg_len = msg_len;
+			memcpy(event->msg, msg, msg_len);
+
+			list_add_tail(&event->list, &ev_pending);
+			wake_up(&rx_queue);
+		}
+
+		mutex_unlock(&priv->lock);
+	}
+
 	return ret;
 }
 

--- a/drivers/video/fbdev/mxc/mxc_hdmi.c
+++ b/drivers/video/fbdev/mxc/mxc_hdmi.c
@@ -203,7 +203,6 @@ static bool hdcp_init;
 static struct regulator *hdmi_regulator;
 
 extern const struct fb_videomode mxc_cea_mode[64];
-extern void mxc_hdmi_cec_handle(u16 cec_stat);
 
 static void mxc_hdmi_setup(struct mxc_hdmi *hdmi, unsigned long event);
 static void hdmi_enable_overflow_interrupts(void);
@@ -2138,7 +2137,7 @@ static void hotplug_worker(struct work_struct *work)
 			kobject_uevent_env(&hdmi->pdev->dev.kobj, KOBJ_CHANGE, envp);
 #ifdef CONFIG_MXC_HDMI_CEC
 			if (hdmi->edid_cfg.hdmi_cap)
-				mxc_hdmi_cec_handle(0x80);
+				hdmi_cec_hpd_changed(1);
 #endif
 		}
 	} else if (hdmi->cable_plugin && !keepalive) {
@@ -2152,7 +2151,7 @@ static void hotplug_worker(struct work_struct *work)
 		kobject_uevent_env(&hdmi->pdev->dev.kobj, KOBJ_CHANGE, envp);
 #ifdef CONFIG_MXC_HDMI_CEC
 		if (hdmi->edid_cfg.hdmi_cap)
-			mxc_hdmi_cec_handle(0x100);
+			hdmi_cec_hpd_changed(0);
 #endif
 	}
 

--- a/include/linux/mfd/mxc-hdmi-core.h
+++ b/include/linux/mfd/mxc-hdmi-core.h
@@ -52,5 +52,6 @@ void mxc_hdmi_unregister_audio(struct snd_pcm_substream *substream);
 unsigned int hdmi_set_cable_state(unsigned int state);
 unsigned int hdmi_set_blank_state(unsigned int state);
 int check_hdmi_state(void);
+void hdmi_cec_hpd_changed(unsigned int state);
 
 #endif


### PR DESCRIPTION
This is a major overhaul of the hdmi-cec driver. It's based on the initial work by @wolfgar and is compatible with his libCEC implementation. It's the adaption of #42 to the 4.9 kernel series.
